### PR TITLE
chore: update scanner pins

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,3 +1,3 @@
 // Single source of truth - keep this in sync with package.json.
-export const APP_VERSION = "0.1.2"
+export const APP_VERSION = "0.1.3"
 export const DISPLAY_VERSION = `v${APP_VERSION}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackray",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=3813cfd007307af911fe6494b85073e390109561
+ARG HTTPX_REF=350afca9a0bc2cf39989a50364b41b3c2e5a01b4
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=3813cfd007307af911fe6494b85073e390109561
+ARG HTTPX_REF=350afca9a0bc2cf39989a50364b41b3c2e5a01b4
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -3,7 +3,7 @@
     "repo": "CarlosCommits/httpx",
     "gitUrl": "https://github.com/CarlosCommits/httpx.git",
     "sourceRef": "dev",
-    "ref": "3813cfd007307af911fe6494b85073e390109561"
+    "ref": "350afca9a0bc2cf39989a50364b41b3c2e5a01b4"
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, and nuclei-template inputs used by the worker image.
- Bump Stackray patch version so deployments can detect the new tested scanner bundle.

`httpx: 3813cfd -> 350afca; nuclei: v3.8.0 -> v3.8.0; nuclei-templates: d6eef2c -> d6eef2c`

Release version: `v0.1.3`