### PR TITLE
Promote DNS service matches into scan technologies

### DIFF
--- a/drizzle/migrations/0008_flowery_the_santerians.sql
+++ b/drizzle/migrations/0008_flowery_the_santerians.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."technology_source" ADD VALUE 'nuclei';

--- a/drizzle/migrations/meta/0008_snapshot.json
+++ b/drizzle/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2961 @@
+{
+  "id": "77a3cefd-f4e0-46eb-a88c-2593ae0e6c04",
+  "prevId": "33fb6f4e-179f-4dec-a61a-f636a627486d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hint": {
+          "name": "token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token_hash": {
+          "name": "idx_api_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_created_by_user_id_users_id_fk": {
+          "name": "api_tokens_created_by_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_accounts_provider_account": {
+          "name": "idx_auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_accounts_user_id": {
+          "name": "idx_auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_sessions_token": {
+          "name": "idx_auth_sessions_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_sessions_user_id": {
+          "name": "idx_auth_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_verifications_identifier": {
+          "name": "idx_auth_verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canonical_targets": {
+      "name": "canonical_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "canonical_targets_normalized_target_unique": {
+          "name": "canonical_targets_normalized_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_target"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_attempts": {
+      "name": "scan_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_scan_attempts_scan_id_status": {
+          "name": "idx_scan_attempts_scan_id_status",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_attempts_scan_id_scans_id_fk": {
+          "name": "scan_attempts_scan_id_scans_id_fk",
+          "tableFrom": "scan_attempts",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_attempts_scan_id_attempt_number_unique": {
+          "name": "scan_attempts_scan_id_attempt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_id",
+            "attempt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_comparisons": {
+      "name": "scan_comparisons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "baseline_scan_id": {
+          "name": "baseline_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_scan_id": {
+          "name": "comparison_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff_json": {
+          "name": "diff_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_comparisons_baseline_scan_id_scans_id_fk": {
+          "name": "scan_comparisons_baseline_scan_id_scans_id_fk",
+          "tableFrom": "scan_comparisons",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "baseline_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comparisons_comparison_scan_id_scans_id_fk": {
+          "name": "scan_comparisons_comparison_scan_id_scans_id_fk",
+          "tableFrom": "scan_comparisons",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "comparison_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_comparisons_baseline_scan_id_comparison_scan_id_unique": {
+          "name": "scan_comparisons_baseline_scan_id_comparison_scan_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "baseline_scan_id",
+            "comparison_scan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_events": {
+      "name": "scan_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "scan_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_events_scan_id_id": {
+          "name": "idx_scan_events_scan_id_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_events_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_detections": {
+      "name": "scan_result_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "scan_result_detection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "technology_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpe": {
+          "name": "cpe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_detections_result_id": {
+          "name": "idx_scan_result_detections_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_detections_result_id_kind": {
+          "name": "idx_scan_result_detections_result_id_kind",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_detections_kind_name": {
+          "name": "idx_scan_result_detections_kind_name",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_detections_result_id_scan_results_id_fk": {
+          "name": "scan_result_detections_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_detections",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_nuclei_matches": {
+      "name": "scan_result_nuclei_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_path": {
+          "name": "template_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matcher_name": {
+          "name": "matcher_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_type": {
+          "name": "protocol_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_at": {
+          "name": "matched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_results_json": {
+          "name": "extracted_results_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "technology_name": {
+          "name": "technology_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technology_version": {
+          "name": "technology_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_kind": {
+          "name": "finding_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_nuclei_matches_result_id": {
+          "name": "idx_scan_result_nuclei_matches_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_nuclei_matches_run_id": {
+          "name": "idx_scan_result_nuclei_matches_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_nuclei_matches_template_id": {
+          "name": "idx_scan_result_nuclei_matches_template_id",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_nuclei_matches_run_id_scan_result_nuclei_runs_id_fk": {
+          "name": "scan_result_nuclei_matches_run_id_scan_result_nuclei_runs_id_fk",
+          "tableFrom": "scan_result_nuclei_matches",
+          "tableTo": "scan_result_nuclei_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_result_nuclei_matches_result_id_scan_results_id_fk": {
+          "name": "scan_result_nuclei_matches_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_nuclei_matches",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_nuclei_runs": {
+      "name": "scan_result_nuclei_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_result_nuclei_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_domain_target": {
+          "name": "original_domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_domain_target": {
+          "name": "final_domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_target": {
+          "name": "domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "template_ids_json": {
+          "name": "template_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "templates_version": {
+          "name": "templates_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_nuclei_runs_result_id": {
+          "name": "idx_scan_result_nuclei_runs_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_nuclei_runs_result_id_scan_results_id_fk": {
+          "name": "scan_result_nuclei_runs_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_nuclei_runs",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_results": {
+      "name": "scan_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_url": {
+          "name": "final_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_ip": {
+          "name": "host_ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_server": {
+          "name": "web_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "words": {
+          "name": "words",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines": {
+          "name": "lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn": {
+          "name": "cdn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_name": {
+          "name": "cdn_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_type": {
+          "name": "cdn_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_mmh3": {
+          "name": "favicon_mmh3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_md5": {
+          "name": "favicon_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_path": {
+          "name": "favicon_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sni": {
+          "name": "sni",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jarm_hash": {
+          "name": "jarm_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_preview": {
+          "name": "body_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers_json": {
+          "name": "response_headers_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_a_records": {
+          "name": "dns_a_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_aaaa_records": {
+          "name": "dns_aaaa_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_cname_records": {
+          "name": "dns_cname_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_resolvers": {
+          "name": "dns_resolvers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asn_json": {
+          "name": "asn_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_json": {
+          "name": "tls_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csp_json": {
+          "name": "csp_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashes_json": {
+          "name": "hashes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_domains": {
+          "name": "body_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_fqdns": {
+          "name": "body_fqdns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_chain_status_codes": {
+          "name": "redirect_chain_status_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_chain_json": {
+          "name": "redirect_chain_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http2": {
+          "name": "http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websocket": {
+          "name": "websocket",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vhost": {
+          "name": "vhost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_response_path": {
+          "name": "stored_response_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_object_key": {
+          "name": "screenshot_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_content_type": {
+          "name": "screenshot_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_byte_size": {
+          "name": "screenshot_byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_captured_at": {
+          "name": "screenshot_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed": {
+          "name": "failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_document": {
+          "name": "search_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scan_results_scan_id": {
+          "name": "idx_scan_results_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_status_code": {
+          "name": "idx_scan_results_status_code",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_final_url": {
+          "name": "idx_scan_results_final_url",
+          "columns": [
+            {
+              "expression": "final_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_location": {
+          "name": "idx_scan_results_location",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_host_ip": {
+          "name": "idx_scan_results_host_ip",
+          "columns": [
+            {
+              "expression": "host_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_server": {
+          "name": "idx_scan_results_server",
+          "columns": [
+            {
+              "expression": "web_server",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_cdn_name": {
+          "name": "idx_scan_results_cdn_name",
+          "columns": [
+            {
+              "expression": "cdn_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_jarm_hash": {
+          "name": "idx_scan_results_jarm_hash",
+          "columns": [
+            {
+              "expression": "jarm_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_favicon_mmh3": {
+          "name": "idx_scan_results_favicon_mmh3",
+          "columns": [
+            {
+              "expression": "favicon_mmh3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_results_scan_id_scans_id_fk": {
+          "name": "scan_results_scan_id_scans_id_fk",
+          "tableFrom": "scan_results",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_results_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_results_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_results",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_run_scans": {
+      "name": "scan_schedule_run_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_run_id": {
+          "name": "schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedule_run_scans_scan_id": {
+          "name": "idx_scan_schedule_run_scans_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedule_run_scans_schedule_run_id_sort_order": {
+          "name": "idx_scan_schedule_run_scans_schedule_run_id_sort_order",
+          "columns": [
+            {
+              "expression": "schedule_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedule_run_scans_schedule_run_id_scan_schedule_runs_id_fk": {
+          "name": "scan_schedule_run_scans_schedule_run_id_scan_schedule_runs_id_fk",
+          "tableFrom": "scan_schedule_run_scans",
+          "tableTo": "scan_schedule_runs",
+          "columnsFrom": [
+            "schedule_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_schedule_run_scans_scan_id_scans_id_fk": {
+          "name": "scan_schedule_run_scans_scan_id_scans_id_fk",
+          "tableFrom": "scan_schedule_run_scans",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_run_scans_schedule_run_id_scan_id_unique": {
+          "name": "scan_schedule_run_scans_schedule_run_id_scan_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_run_id",
+            "scan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_runs": {
+      "name": "scan_schedule_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_schedule_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_at": {
+          "name": "scheduled_for_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_scan_count": {
+          "name": "queued_scan_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedule_runs_schedule_id_created_at": {
+          "name": "idx_scan_schedule_runs_schedule_id_created_at",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedule_runs_schedule_id_scheduled_for_at": {
+          "name": "idx_scan_schedule_runs_schedule_id_scheduled_for_at",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedule_runs_schedule_id_scan_schedules_id_fk": {
+          "name": "scan_schedule_runs_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scan_schedule_runs",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_runs_schedule_id_scheduled_for_at_unique": {
+          "name": "scan_schedule_runs_schedule_id_scheduled_for_at_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "scheduled_for_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_targets": {
+      "name": "scan_schedule_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_target_id": {
+          "name": "canonical_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_target": {
+          "name": "input_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_schedule_targets_schedule_id_scan_schedules_id_fk": {
+          "name": "scan_schedule_targets_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scan_schedule_targets",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_schedule_targets_canonical_target_id_canonical_targets_id_fk": {
+          "name": "scan_schedule_targets_canonical_target_id_canonical_targets_id_fk",
+          "tableFrom": "scan_schedule_targets",
+          "tableTo": "canonical_targets",
+          "columnsFrom": [
+            "canonical_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_targets_schedule_id_normalized_target_unique": {
+          "name": "scan_schedule_targets_schedule_id_normalized_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "normalized_target"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedules": {
+      "name": "scan_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "scan_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minute": {
+          "name": "minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedules_created_by_user_id": {
+          "name": "idx_scan_schedules_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedules_enabled_next_run_at": {
+          "name": "idx_scan_schedules_enabled_next_run_at",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedules_created_by_user_id_users_id_fk": {
+          "name": "scan_schedules_created_by_user_id_users_id_fk",
+          "tableFrom": "scan_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scans": {
+      "name": "scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_token_id": {
+          "name": "created_by_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "scan_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_schema_version": {
+          "name": "request_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "canonical_target_id": {
+          "name": "canonical_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_target": {
+          "name": "input_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scheduled_for_at": {
+          "name": "scheduled_for_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scans_submitted_at": {
+          "name": "idx_scans_submitted_at",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_status": {
+          "name": "idx_scans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_schedule_id": {
+          "name": "idx_scans_schedule_id",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_normalized_target": {
+          "name": "idx_scans_normalized_target",
+          "columns": [
+            {
+              "expression": "normalized_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_request_fingerprint": {
+          "name": "idx_scans_request_fingerprint",
+          "columns": [
+            {
+              "expression": "request_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_idempotency_key": {
+          "name": "idx_scans_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"scans\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_schedule_slot": {
+          "name": "idx_scans_schedule_slot",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scans_created_by_user_id_users_id_fk": {
+          "name": "scans_created_by_user_id_users_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_created_by_token_id_api_tokens_id_fk": {
+          "name": "scans_created_by_token_id_api_tokens_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "api_tokens",
+          "columnsFrom": [
+            "created_by_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_schedule_id_scan_schedules_id_fk": {
+          "name": "scans_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_canonical_target_id_canonical_targets_id_fk": {
+          "name": "scans_canonical_target_id_canonical_targets_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "canonical_targets",
+          "columnsFrom": [
+            "canonical_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_product_state": {
+      "name": "user_product_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_release_version": {
+          "name": "last_seen_release_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "getting_started_dismissed_at": {
+          "name": "getting_started_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_state_user_id_users_id_fk": {
+          "name": "user_product_state_user_id_users_id_fk",
+          "tableFrom": "user_product_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_access_enabled": {
+          "name": "api_token_access_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_change_required_at": {
+          "name": "password_change_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_status": {
+      "name": "attempt_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.scan_result_detection_kind": {
+      "name": "scan_result_detection_kind",
+      "schema": "public",
+      "values": [
+        "technology",
+        "wordpress_plugin",
+        "wordpress_theme",
+        "cpe"
+      ]
+    },
+    "public.scan_result_nuclei_run_status": {
+      "name": "scan_result_nuclei_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.scan_event_type": {
+      "name": "scan_event_type",
+      "schema": "public",
+      "values": [
+        "scan.status",
+        "scan.progress",
+        "scan.result",
+        "scan.complete",
+        "scan.failed",
+        "scan.cancelled"
+      ]
+    },
+    "public.scan_schedule_frequency": {
+      "name": "scan_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.scan_schedule_run_status": {
+      "name": "scan_schedule_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.scan_source": {
+      "name": "scan_source",
+      "schema": "public",
+      "values": [
+        "ui",
+        "cli",
+        "api",
+        "system"
+      ]
+    },
+    "public.scan_status": {
+      "name": "scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "running",
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.target_type": {
+      "name": "target_type",
+      "schema": "public",
+      "values": [
+        "url",
+        "host",
+        "domain"
+      ]
+    },
+    "public.technology_source": {
+      "name": "technology_source",
+      "schema": "public",
+      "values": [
+        "wappalyzer",
+        "wordpress",
+        "cpe",
+        "derived",
+        "nuclei"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776629613515,
       "tag": "0007_loving_jetstream",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778635038311,
+      "tag": "0008_flowery_the_santerians",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -49,6 +49,7 @@ export const techSourceEnum = pgEnum("technology_source", [
   "wordpress",
   "cpe",
   "derived",
+  "nuclei",
 ]);
 
 export const detectionKindEnum = pgEnum("scan_result_detection_kind", [

--- a/lib/server/scans/read-service.test.ts
+++ b/lib/server/scans/read-service.test.ts
@@ -150,7 +150,10 @@ function createCompletedSnapshot(overrides: Partial<CompletedResultSnapshot> = {
 
 function createDecorations(): ResultDecorations {
   return {
-    technologies: [{ name: "Nginx", version: null, source: "wappalyzer" }],
+    technologies: [
+      { name: "Nginx", version: null, source: "wappalyzer" },
+      { name: "Next.js", version: null, source: "nuclei" },
+    ],
     wordpressPlugins: [],
     wordpressThemes: [],
     cpe: [],
@@ -235,7 +238,7 @@ function createDecorations(): ResultDecorations {
 }
 
 describe("mapResultItem", () => {
-  it("merges nuclei technology names into visible technologies and exposes nuclei provenance", () => {
+  it("reads persisted nuclei technology detections and exposes nuclei provenance", () => {
     const parsed = scanResultItemSchema.parse(
       mapResultItem(createResultRecord(), createScanRecord(), createDecorations()),
     );
@@ -280,8 +283,9 @@ describe("mapResultItem", () => {
     expect(parsed.nuclei?.findings[0]?.technologyName).toBeNull();
   });
 
-  it("promotes nuclei DNS service matches into technology detections", () => {
+  it("reads persisted nuclei DNS service technology detections", () => {
     const decorations = createDecorations();
+    decorations.technologies.push({ name: "Brevo", version: null, source: "nuclei" });
     decorations.nucleiMatches.push({
       id: "nm_dns_service",
       runId: "nr_01",
@@ -387,6 +391,7 @@ describe("mapResultItem", () => {
         technologies: [
           { name: "Nginx", version: null, source: "wappalyzer" },
           { name: "Nginx", version: null, source: "cpe" },
+          { name: "Next.js", version: null, source: "nuclei" },
         ],
       },
     );

--- a/lib/server/scans/read-service.test.ts
+++ b/lib/server/scans/read-service.test.ts
@@ -280,6 +280,55 @@ describe("mapResultItem", () => {
     expect(parsed.nuclei?.findings[0]?.technologyName).toBeNull();
   });
 
+  it("promotes nuclei DNS service matches into technology detections", () => {
+    const decorations = createDecorations();
+    decorations.nucleiMatches.push({
+      id: "nm_dns_service",
+      runId: "nr_01",
+      resultId: "res_01",
+      templateId: "txt-service-detect",
+      templatePath: "dns/txt-service-detect.yaml",
+      matcherName: "brevo",
+      protocolType: "dns",
+      severity: "info",
+      matchedAt: "alphacompany.com",
+      host: "alphacompany.com",
+      ip: null,
+      port: null,
+      scheme: null,
+      url: null,
+      path: null,
+      extractedResultsJson: ["brevo-code:f6498ae8180a890715fbd4b5f03bd728"],
+      technologyName: null,
+      technologyVersion: null,
+      findingKind: "dns_service",
+      subject: "alphacompany.com",
+      subjectType: "domain",
+      rawJson: {
+        "template-id": "txt-service-detect",
+        "matcher-name": "brevo",
+      },
+      createdAt: new Date("2026-03-27T00:01:03.000Z"),
+    });
+
+    const parsed = scanResultItemSchema.parse(
+      mapResultItem(createResultRecord(), createScanRecord(), decorations),
+    );
+
+    expect(parsed.technologies).toContain("Brevo");
+    expect(parsed.technologyDetections).toContainEqual(expect.objectContaining({
+      name: "Brevo",
+      bucket: "business",
+      sources: ["nuclei"],
+      inferred: true,
+    }));
+    expect(parsed.nuclei.findings).toContainEqual(expect.objectContaining({
+      findingKind: "dns_service",
+      matcherName: "brevo",
+      extractedResults: ["brevo-code:f6498ae8180a890715fbd4b5f03bd728"],
+    }));
+  });
+
   it("returns a stable not_run nuclei block when no enrichment data exists", () => {
     const parsed = scanResultItemSchema.parse(
       mapResultItem(createResultRecord(), createScanRecord(), {

--- a/lib/server/scans/read-service.ts
+++ b/lib/server/scans/read-service.ts
@@ -29,7 +29,6 @@ import {
   buildEnrichedTechnologies,
   buildEnrichedTechnologyDetections,
   deriveTechnologiesFromEvidence,
-  getNucleiDnsServiceTechnologyName,
   type TechnologyEvidenceItem,
 } from "@/lib/server/scans/technology-enrichment";
 import { normalizeRedirectChainItems } from "@/lib/server/scans/redirect-chain";
@@ -444,43 +443,9 @@ function buildNucleiBlock(decorations: ResultDecorations | undefined) {
   };
 }
 
-function getPromotedNucleiTechnologyNames(decorations: ResultDecorations | undefined) {
-  const names: string[] = [];
-  const seen = new Set<string>();
-
-  const appendName = (name: string | null) => {
-    if (!name) {
-      return;
-    }
-
-    const normalizedName = normalizeTechnologyKey(name);
-
-    if (!normalizedName || seen.has(normalizedName)) {
-      return;
-    }
-
-    seen.add(normalizedName);
-    names.push(name);
-  };
-
-  for (const technologyName of decorations?.nucleiTechnologyNames ?? []) {
-    appendName(technologyName);
-  }
-
-  for (const match of decorations?.nucleiMatches ?? []) {
-    appendName(getNucleiDnsServiceTechnologyName({
-      findingKind: match.findingKind,
-      matcherName: match.matcherName,
-    }));
-  }
-
-  return names;
-}
-
 function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologies({
     persistedTechnologies: (decorations?.technologies ?? []).map((technology) => technology.name),
-    additionalTechnologies: getPromotedNucleiTechnologyNames(decorations),
     cpeEntries: decorations?.cpe ?? [],
     cspJson: parseJsonObject(result.cspJson),
     bodyDomains: parseJsonArray(result.bodyDomains),
@@ -491,11 +456,6 @@ function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorat
 function getStructuredTechnologyDetections(result: ResultRecord, decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologyDetections({
     persistedTechnologies: decorations?.technologies ?? [],
-    additionalTechnologies: getPromotedNucleiTechnologyNames(decorations).map((name) => ({
-      name,
-      version: null,
-      source: "nuclei" as const,
-    })),
     cpeEntries: decorations?.cpe ?? [],
     cspJson: parseJsonObject(result.cspJson),
     bodyDomains: parseJsonArray(result.bodyDomains),
@@ -617,15 +577,6 @@ export function mapTechnologyInventoryItems(result: ResultRecord, scan: ScanReco
       name: technology.name,
       version: technology.version,
       inferred: technology.source !== "wappalyzer" && technology.source !== "wordpress",
-    });
-  }
-
-  for (const technologyName of getPromotedNucleiTechnologyNames(decorations)) {
-    appendTechnologyLikeItem({
-      kind: "technology",
-      source: "nuclei",
-      name: technologyName,
-      inferred: true,
     });
   }
 

--- a/lib/server/scans/read-service.ts
+++ b/lib/server/scans/read-service.ts
@@ -29,6 +29,7 @@ import {
   buildEnrichedTechnologies,
   buildEnrichedTechnologyDetections,
   deriveTechnologiesFromEvidence,
+  getNucleiDnsServiceTechnologyName,
   type TechnologyEvidenceItem,
 } from "@/lib/server/scans/technology-enrichment";
 import { normalizeRedirectChainItems } from "@/lib/server/scans/redirect-chain";
@@ -443,10 +444,43 @@ function buildNucleiBlock(decorations: ResultDecorations | undefined) {
   };
 }
 
+function getPromotedNucleiTechnologyNames(decorations: ResultDecorations | undefined) {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  const appendName = (name: string | null) => {
+    if (!name) {
+      return;
+    }
+
+    const normalizedName = normalizeTechnologyKey(name);
+
+    if (!normalizedName || seen.has(normalizedName)) {
+      return;
+    }
+
+    seen.add(normalizedName);
+    names.push(name);
+  };
+
+  for (const technologyName of decorations?.nucleiTechnologyNames ?? []) {
+    appendName(technologyName);
+  }
+
+  for (const match of decorations?.nucleiMatches ?? []) {
+    appendName(getNucleiDnsServiceTechnologyName({
+      findingKind: match.findingKind,
+      matcherName: match.matcherName,
+    }));
+  }
+
+  return names;
+}
+
 function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologies({
     persistedTechnologies: (decorations?.technologies ?? []).map((technology) => technology.name),
-    additionalTechnologies: decorations?.nucleiTechnologyNames ?? [],
+    additionalTechnologies: getPromotedNucleiTechnologyNames(decorations),
     cpeEntries: decorations?.cpe ?? [],
     cspJson: parseJsonObject(result.cspJson),
     bodyDomains: parseJsonArray(result.bodyDomains),
@@ -457,7 +491,7 @@ function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorat
 function getStructuredTechnologyDetections(result: ResultRecord, decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologyDetections({
     persistedTechnologies: decorations?.technologies ?? [],
-    additionalTechnologies: (decorations?.nucleiTechnologyNames ?? []).map((name) => ({
+    additionalTechnologies: getPromotedNucleiTechnologyNames(decorations).map((name) => ({
       name,
       version: null,
       source: "nuclei" as const,
@@ -586,7 +620,7 @@ export function mapTechnologyInventoryItems(result: ResultRecord, scan: ScanReco
     });
   }
 
-  for (const technologyName of decorations?.nucleiTechnologyNames ?? []) {
+  for (const technologyName of getPromotedNucleiTechnologyNames(decorations)) {
     appendTechnologyLikeItem({
       kind: "technology",
       source: "nuclei",

--- a/lib/server/scans/scan-detail-view-model.test.ts
+++ b/lib/server/scans/scan-detail-view-model.test.ts
@@ -448,6 +448,42 @@ describe("scan-detail-view-model", () => {
       expect(section.dnsServices[0].provenance).toBe("original")
     })
 
+    it("should prefer clean DNS service matcher names over raw TXT values", () => {
+      const result = createMockResult({
+        nuclei: {
+          ...createMockResult().nuclei,
+          findings: [
+            {
+              matchId: "finding-brevo",
+              templateId: "txt-service-detect",
+              templatePath: "dns/txt-service-detect.yaml",
+              matcherName: "brevo",
+              protocolType: "dns",
+              severity: "info",
+              matchedAt: "example.com",
+              host: "example.com",
+              ip: null,
+              port: null,
+              scheme: null,
+              url: null,
+              path: null,
+              extractedResults: ["brevo-code:f6498ae8180a890715fbd4b5f03bd728"],
+              technologyName: null,
+              technologyVersion: null,
+              findingKind: "dns_service",
+              subject: "example.com",
+              subjectType: "domain",
+              raw: { "matcher-name": "brevo" },
+            },
+          ],
+        },
+      })
+
+      const section = buildDnsInfrastructureSection(result)
+
+      expect(section.dnsServices[0].serviceName).toBe("Brevo")
+    })
+
     it("should extract nameservers from domain metadata with case-insensitive deduplication", () => {
       const result = createMockResult({
         nuclei: {

--- a/lib/server/scans/scan-detail-view-model.ts
+++ b/lib/server/scans/scan-detail-view-model.ts
@@ -7,6 +7,7 @@ import {
   type StructuredTechnologyDetection,
   type TechnologyBucketId,
 } from "@/lib/server/scans/technology-metadata-catalog";
+import { getNucleiDnsServiceTechnologyName } from "@/lib/server/scans/technology-enrichment";
 import { resolveHostingDisplay } from "@/lib/server/scans/hosting-display";
 
 // Section view-model types
@@ -439,8 +440,9 @@ export function buildDnsInfrastructureSection(result: ScanResultItem): DnsInfras
     );
 
     if (finding.findingKind === "dns_service") {
-      // Extract service name from extracted results or template ID
-      const serviceName = finding.extractedResults[0] ??
+      // Prefer the template matcher because extracted TXT values often contain raw verification secrets.
+      const serviceName = getNucleiDnsServiceTechnologyName(finding) ??
+        finding.extractedResults[0] ??
         finding.matcherName ??
         finding.templateId;
 

--- a/lib/server/scans/technology-enrichment.test.ts
+++ b/lib/server/scans/technology-enrichment.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildEnrichedTechnologies,
   deriveTechnologiesFromEvidence,
+  getNucleiDnsServiceTechnologyName,
   promoteTechnologiesFromCpe,
 } from "@/lib/server/scans/technology-enrichment";
 
@@ -72,6 +73,32 @@ describe("deriveTechnologiesFromEvidence", () => {
         bodyFqdns: ["cdn.jsdelivr.net"],
       }),
     ).toEqual([]);
+  });
+});
+
+describe("getNucleiDnsServiceTechnologyName", () => {
+  it("promotes clean DNS service matcher names into canonical technology names", () => {
+    expect(getNucleiDnsServiceTechnologyName({
+      findingKind: "dns_service",
+      matcherName: "brevo",
+    })).toBe("Brevo");
+
+    expect(getNucleiDnsServiceTechnologyName({
+      findingKind: "dns_service",
+      matcherName: "google-workspace",
+    })).toBe("Google Workspace");
+  });
+
+  it("ignores non DNS-service findings and matches without a service matcher", () => {
+    expect(getNucleiDnsServiceTechnologyName({
+      findingKind: "txt_record",
+      matcherName: "brevo",
+    })).toBeNull();
+
+    expect(getNucleiDnsServiceTechnologyName({
+      findingKind: "dns_service",
+      matcherName: null,
+    })).toBeNull();
   });
 });
 

--- a/lib/server/scans/technology-enrichment.ts
+++ b/lib/server/scans/technology-enrichment.ts
@@ -32,6 +32,11 @@ type DomainTechnologyRule = {
   domains: readonly string[];
 };
 
+type NucleiServiceTechnologyMatch = {
+  findingKind: string | null;
+  matcherName: string | null;
+};
+
 const promotedCpeTechnologyNames = new Map<string, string>([
   ["vercel:next.js", "Next.js"],
   ["zeit:next.js", "Next.js"],
@@ -41,6 +46,18 @@ const promotedCpeTechnologyNames = new Map<string, string>([
   ["joomla:joomla\!", "Joomla!"],
   ["magento:magento", "Magento"],
   ["shopify:shopify", "Shopify"],
+]);
+
+const titleCaseAcronyms = new Map<string, string>([
+  ["ai", "AI"],
+  ["api", "API"],
+  ["cdn", "CDN"],
+  ["ci", "CI"],
+  ["crm", "CRM"],
+  ["dns", "DNS"],
+  ["sso", "SSO"],
+  ["ssl", "SSL"],
+  ["tls", "TLS"],
 ]);
 
 const derivedTechnologyDomainRules: DomainTechnologyRule[] = [
@@ -92,6 +109,18 @@ const derivedTechnologyDomainRules: DomainTechnologyRule[] = [
 
 function normalizeTechnologyName(value: string) {
   return canonicalizeTechnologyLabel(value).name.trim().toLowerCase();
+}
+
+function toTechnologyTitleCase(value: string) {
+  return value
+    .split(/[-_\s]+/u)
+    .filter(Boolean)
+    .map((part) => {
+      const normalized = part.toLowerCase();
+
+      return titleCaseAcronyms.get(normalized) ?? normalized.charAt(0).toUpperCase() + normalized.slice(1);
+    })
+    .join(" ");
 }
 
 function normalizeDomain(value: string) {
@@ -185,6 +214,26 @@ export function promoteTechnologiesFromCpe(cpeEntries: readonly CpeEntry[]) {
   }
 
   return promotedTechnologyNames;
+}
+
+export function getNucleiDnsServiceTechnologyName(match: NucleiServiceTechnologyMatch) {
+  if (match.findingKind !== "dns_service") {
+    return null;
+  }
+
+  const matcherName = match.matcherName?.trim();
+
+  if (!matcherName) {
+    return null;
+  }
+
+  const canonicalName = canonicalizeTechnologyLabel(matcherName).name;
+
+  if (canonicalName !== matcherName) {
+    return canonicalName;
+  }
+
+  return canonicalizeTechnologyLabel(toTechnologyTitleCase(matcherName)).name;
 }
 
 export function deriveTechnologiesFromEvidence({

--- a/worker/scan-worker.test.ts
+++ b/worker/scan-worker.test.ts
@@ -11,6 +11,7 @@ import {
   buildNucleiExecutionPhases,
   buildHttpxArguments,
   buildHttpxHeadlessEnrichmentArguments,
+  buildNucleiTechnologyDetectionRows,
   buildScreenshotTechnologyDetectionRows,
   buildStoredResultSearchDocument,
   extractFaviconFields,
@@ -461,6 +462,61 @@ describe("buildScreenshotTechnologyDetectionRows", () => {
         source: "wappalyzer",
         name: "React",
         version: "18.2.0",
+      }),
+    ]);
+  });
+});
+
+describe("buildNucleiTechnologyDetectionRows", () => {
+  it("materializes nuclei technology and DNS service matches as technology detections", () => {
+    const rows = buildNucleiTechnologyDetectionRows({
+      resultId: "result-1",
+      matches: [
+        {
+          findingKind: "technology",
+          matcherName: "Next.js",
+          technologyName: "Next.js",
+          technologyVersion: null,
+        },
+        {
+          findingKind: "dns_service",
+          matcherName: "brevo",
+          technologyName: null,
+          technologyVersion: null,
+        },
+        {
+          findingKind: "dns_service",
+          matcherName: "google-workspace",
+          technologyName: null,
+          technologyVersion: null,
+        },
+        {
+          findingKind: "ssl_issuer",
+          matcherName: "Let's Encrypt",
+          technologyName: null,
+          technologyVersion: null,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        resultId: "result-1",
+        kind: "technology",
+        source: "nuclei",
+        name: "Next.js",
+      }),
+      expect.objectContaining({
+        resultId: "result-1",
+        kind: "technology",
+        source: "nuclei",
+        name: "Brevo",
+      }),
+      expect.objectContaining({
+        resultId: "result-1",
+        kind: "technology",
+        source: "nuclei",
+        name: "Google Workspace",
       }),
     ]);
   });

--- a/worker/scan-worker.ts
+++ b/worker/scan-worker.ts
@@ -409,6 +409,52 @@ function buildDetectionRows(input: {
   return detectionRows;
 }
 
+export function buildNucleiTechnologyDetectionRows(input: {
+  resultId: string;
+  matches: readonly { findingKind: string; matcherName: string | null; technologyName: string | null; technologyVersion: string | null }[];
+}) {
+  const detectionRows: DetectionInsert[] = [];
+  const seen = new Set<string>();
+
+  for (const match of input.matches) {
+    const technologyName = match.technologyName ?? getNucleiDnsServiceTechnologyName({
+      findingKind: match.findingKind,
+      matcherName: match.matcherName,
+    });
+
+    if (!technologyName) {
+      continue;
+    }
+
+    const canonicalTechnology = canonicalizeTechnologyLabel(technologyName);
+    const version = match.technologyVersion ?? canonicalTechnology.version;
+    const key = [
+      canonicalTechnology.name.trim().toLowerCase(),
+      version?.trim().toLowerCase() ?? "",
+    ].join("::");
+
+    if (!canonicalTechnology.name.trim() || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+
+    detectionRows.push({
+      resultId: input.resultId,
+      kind: "technology",
+      name: canonicalTechnology.name,
+      version,
+      source: "nuclei",
+      slug: null,
+      vendor: null,
+      product: null,
+      cpe: null,
+    });
+  }
+
+  return detectionRows;
+}
+
 export function buildScreenshotTechnologyDetectionRows(input: {
   resultId: string;
   technologies: readonly string[];
@@ -589,17 +635,6 @@ function collectUniqueTechnologyNames(technologyNames: readonly (string | null)[
   }
 
   return visibleTechnologyNames;
-}
-
-function collectNucleiTechnologyNames(
-  matches: readonly { findingKind: string; matcherName: string | null; technologyName: string | null }[],
-) {
-  return collectUniqueTechnologyNames(matches.map((match) => (
-    match.technologyName ?? getNucleiDnsServiceTechnologyName({
-      findingKind: match.findingKind,
-      matcherName: match.matcherName,
-    })
-  )));
 }
 
 function buildStoredResultVisibleTechnologies(
@@ -1574,6 +1609,18 @@ async function updateResultSearchDocument(result: ScanResultRow, nucleiTechnolog
     .where(eq(scanResults.id, result.id));
 }
 
+async function deleteNucleiTechnologyDetections(resultId: string) {
+  await db
+    .delete(scanResultDetections)
+    .where(
+      and(
+        eq(scanResultDetections.resultId, resultId),
+        eq(scanResultDetections.kind, "technology"),
+        eq(scanResultDetections.source, "nuclei"),
+      ),
+    );
+}
+
 async function getPersistedTechnologyNames(resultId: string) {
   const rows = await db
     .select({
@@ -1685,6 +1732,7 @@ async function enrichResultWithNuclei(
       startedAt: completedAt,
       completedAt,
     });
+    await deleteNucleiTechnologyDetections(result.id);
     await updateResultSearchDocument(result, []);
 
     logWorkerEvent("nuclei_enrichment_skipped", {
@@ -1711,6 +1759,7 @@ async function enrichResultWithNuclei(
   });
 
   await db.delete(scanResultNucleiMatches).where(eq(scanResultNucleiMatches.runId, run.id));
+  await deleteNucleiTechnologyDetections(result.id);
 
   logWorkerEvent("nuclei_enrichment_started", {
     scanId,
@@ -1810,7 +1859,16 @@ async function enrichResultWithNuclei(
       );
     }
 
-    const nucleiTechnologyNames = collectNucleiTechnologyNames(matches);
+    const nucleiTechnologyRows = buildNucleiTechnologyDetectionRows({
+      resultId: result.id,
+      matches,
+    });
+
+    if (nucleiTechnologyRows.length > 0) {
+      await db.insert(scanResultDetections).values(nucleiTechnologyRows);
+    }
+
+    const nucleiTechnologyNames = nucleiTechnologyRows.map((row) => row.name);
 
     await upsertNucleiRunState({
       resultId: result.id,
@@ -1824,7 +1882,7 @@ async function enrichResultWithNuclei(
       startedAt,
       completedAt: new Date(),
     });
-    await updateResultSearchDocument(result, nucleiTechnologyNames);
+    await updateResultSearchDocument(result, []);
 
     logWorkerEvent("nuclei_enrichment_completed", {
       scanId,

--- a/worker/scan-worker.ts
+++ b/worker/scan-worker.ts
@@ -20,7 +20,7 @@ import {
 import { db } from "./db.ts";
 import { env } from "../lib/env/server.ts";
 import { buildScreenshotObjectKey, screenshotStorageEnabled, uploadScreenshotObject } from "../lib/server/storage/screenshots.ts";
-import { buildEnrichedTechnologies, promoteTechnologiesFromCpe } from "../lib/server/scans/technology-enrichment.ts";
+import { buildEnrichedTechnologies, getNucleiDnsServiceTechnologyName, promoteTechnologiesFromCpe } from "../lib/server/scans/technology-enrichment.ts";
 import { canonicalizeTechnologyLabel } from "../lib/server/scans/technology-metadata-catalog.ts";
 import { getExecutionTarget } from "../lib/server/scans/normalize-targets.ts";
 import {
@@ -589,6 +589,17 @@ function collectUniqueTechnologyNames(technologyNames: readonly (string | null)[
   }
 
   return visibleTechnologyNames;
+}
+
+function collectNucleiTechnologyNames(
+  matches: readonly { findingKind: string; matcherName: string | null; technologyName: string | null }[],
+) {
+  return collectUniqueTechnologyNames(matches.map((match) => (
+    match.technologyName ?? getNucleiDnsServiceTechnologyName({
+      findingKind: match.findingKind,
+      matcherName: match.matcherName,
+    })
+  )));
 }
 
 function buildStoredResultVisibleTechnologies(
@@ -1799,7 +1810,7 @@ async function enrichResultWithNuclei(
       );
     }
 
-    const nucleiTechnologyNames = collectUniqueTechnologyNames(matches.map((match) => match.technologyName));
+    const nucleiTechnologyNames = collectNucleiTechnologyNames(matches);
 
     await upsertNucleiRunState({
       resultId: result.id,


### PR DESCRIPTION
## Summary
- normalize clean Nuclei DNS service matcher names into canonical technology names
- include promoted DNS services in scan technology lists, structured detections, inventory, and search documents
- show clean service labels in DNS evidence instead of raw TXT verification tokens

## Tests
- pnpm test lib/server/scans/technology-enrichment.test.ts lib/server/scans/read-service.test.ts lib/server/scans/scan-detail-view-model.test.ts worker/scan-worker.test.ts
- pnpm typecheck
- pnpm lint