### PR TITLE
Move derived domain tech detection to Wappalyzer

### DIFF
--- a/lib/server/scans/custom-technology-metadata.json
+++ b/lib/server/scans/custom-technology-metadata.json
@@ -60,5 +60,16 @@
     "implies": [
       "Python"
     ]
+  },
+  "plausibleanalytics": {
+    "name": "Plausible Analytics",
+    "description": "Plausible Analytics is a privacy-focused web analytics platform.",
+    "website": "https://plausible.io/",
+    "icon": null,
+    "cpe": null,
+    "categories": [
+      "Analytics"
+    ],
+    "implies": []
   }
 }

--- a/lib/server/scans/custom-wappalyzer-fingerprints.json
+++ b/lib/server/scans/custom-wappalyzer-fingerprints.json
@@ -23,6 +23,179 @@
       ],
       "implies": []
     },
+    "Contentful": {
+      "cats": [
+        1
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\b(?:contentful\\.com|ctfassets\\.net|ctfapps\\.net)\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:contentful\\.com|ctfassets\\.net|ctfapps\\.net)\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:contentful\\.com|ctfassets\\.net|ctfapps\\.net)\\b"
+      ],
+      "implies": []
+    },
+    "Google Analytics": {
+      "cats": [
+        10
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bgoogle-analytics\\.com\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/www\\.googletagmanager\\.com\\/gtag\\/js\\?id=G-[A-Z0-9-]+",
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bgoogle-analytics\\.com\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/www\\.googletagmanager\\.com\\/gtag\\/js\\?id=G-[A-Z0-9-]+",
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bgoogle-analytics\\.com\\b"
+      ],
+      "implies": []
+    },
+    "Salesforce": {
+      "cats": [
+        53
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\b(?:force\\.com|pardot\\.com|exacttarget\\.com|salesforceliveagent\\.com)\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:force\\.com|pardot\\.com|exacttarget\\.com|salesforceliveagent\\.com)\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:force\\.com|pardot\\.com|exacttarget\\.com|salesforceliveagent\\.com)\\b"
+      ],
+      "implies": []
+    },
+    "Segment": {
+      "cats": [
+        97
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\b(?:segment\\.com|segment\\.io)\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:segment\\.com|segment\\.io)\\b",
+        "\\banalytics\\.load\\(['\"]"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:segment\\.com|segment\\.io)\\b"
+      ],
+      "implies": []
+    },
+    "Marketo": {
+      "cats": [
+        32
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bmarketo\\.net\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bmarketo\\.net\\b",
+        "\\bMunchkin\\.init\\(['\"]"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bmarketo\\.net\\b"
+      ],
+      "implies": []
+    },
+    "Intercom": {
+      "cats": [
+        52,
+        53
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\b(?:intercom\\.io|intercomcdn\\.com)\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:intercom\\.io|intercomcdn\\.com)\\b",
+        "\\bIntercom\\(['\"]boot['\"]"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\b(?:intercom\\.io|intercomcdn\\.com)\\b"
+      ],
+      "implies": []
+    },
+    "Plausible Analytics": {
+      "cats": [
+        10
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bplausible\\.io\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bplausible\\.io\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bplausible\\.io\\b"
+      ],
+      "implies": []
+    },
+    "Sentry": {
+      "cats": [
+        13
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bsentry\\.io\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bsentry\\.io\\b",
+        "\\bSentry\\.init\\("
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bsentry\\.io\\b"
+      ],
+      "implies": []
+    },
+    "Userflow": {
+      "cats": [
+        58
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\buserflow\\.com\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\buserflow\\.com\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\buserflow\\.com\\b"
+      ],
+      "implies": []
+    },
+    "hCaptcha": {
+      "cats": [
+        16
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bhcaptcha\\.com\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bhcaptcha\\.com\\b"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bhcaptcha\\.com\\b"
+      ],
+      "implies": []
+    },
+    "Pusher": {
+      "cats": [
+        52
+      ],
+      "headers": {
+        "content-security-policy": "(?:^|[\\s;])https?:\\/\\/[^\\s;]*\\bpusher\\.com\\b"
+      },
+      "html": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bpusher\\.com\\b",
+        "\\bnew Pusher\\(['\"]"
+      ],
+      "scriptSrc": [
+        "(?:https?:)?\\/\\/[^\\s\"'<>]*\\bpusher\\.com\\b"
+      ],
+      "implies": []
+    },
     "Django": {
       "cats": [
         18

--- a/lib/server/scans/read-service.ts
+++ b/lib/server/scans/read-service.ts
@@ -28,7 +28,6 @@ import { getVisibleScansFilter } from "@/lib/server/scans/access";
 import {
   buildEnrichedTechnologies,
   buildEnrichedTechnologyDetections,
-  deriveTechnologiesFromEvidence,
   type TechnologyEvidenceItem,
 } from "@/lib/server/scans/technology-enrichment";
 import { normalizeRedirectChainItems } from "@/lib/server/scans/redirect-chain";
@@ -448,9 +447,6 @@ function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorat
     persistedTechnologies: (decorations?.technologies ?? []).map((technology) => technology.name),
     additionalTechnologies: decorations?.nucleiTechnologyNames ?? [],
     cpeEntries: decorations?.cpe ?? [],
-    cspJson: parseJsonObject(result.cspJson),
-    bodyDomains: parseJsonArray(result.bodyDomains),
-    bodyFqdns: parseJsonArray(result.bodyFqdns),
   });
 }
 
@@ -463,9 +459,6 @@ function getStructuredTechnologyDetections(result: ResultRecord, decorations: Re
       source: "nuclei" as const,
     })),
     cpeEntries: decorations?.cpe ?? [],
-    cspJson: parseJsonObject(result.cspJson),
-    bodyDomains: parseJsonArray(result.bodyDomains),
-    bodyFqdns: parseJsonArray(result.bodyFqdns),
   });
 }
 
@@ -590,19 +583,6 @@ export function mapTechnologyInventoryItems(result: ResultRecord, scan: ScanReco
     appendTechnologyLikeItem({
       kind: "technology",
       source: "nuclei",
-      name: technologyName,
-      inferred: true,
-    });
-  }
-
-  for (const technologyName of deriveTechnologiesFromEvidence({
-    cspJson: parseJsonObject(result.cspJson),
-    bodyDomains: parseJsonArray(result.bodyDomains),
-    bodyFqdns: parseJsonArray(result.bodyFqdns),
-  })) {
-    appendTechnologyLikeItem({
-      kind: "technology",
-      source: "derived",
       name: technologyName,
       inferred: true,
     });

--- a/lib/server/scans/technology-enrichment.test.ts
+++ b/lib/server/scans/technology-enrichment.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildEnrichedTechnologies,
-  deriveTechnologiesFromEvidence,
   promoteTechnologiesFromCpe,
 } from "@/lib/server/scans/technology-enrichment";
 
@@ -47,36 +46,8 @@ describe("promoteTechnologiesFromCpe", () => {
   });
 });
 
-describe("deriveTechnologiesFromEvidence", () => {
-  it("derives vendor technologies from high-signal domains and CSP hosts", () => {
-    expect(
-      deriveTechnologiesFromEvidence({
-        cspJson: {
-          domains: ["contentful.com", "segment.com"],
-          fqdn: ["munchkin.marketo.net", "js.intercomcdn.com"],
-        },
-        bodyDomains: ["plausible.io", "google-analytics.com", "openai.com"],
-        bodyFqdns: ["newassets.hcaptcha.com", "api.segment.com"],
-      }),
-    ).toEqual(["Contentful", "Google Analytics", "Segment", "Marketo", "Intercom", "Plausible Analytics", "hCaptcha"]);
-  });
-
-  it("ignores domains outside the curated allowlist", () => {
-    expect(
-      deriveTechnologiesFromEvidence({
-        cspJson: {
-          domains: ["facebook.com", "linkedin.com", "stripe.com"],
-          fqdn: ["images.example.com"],
-        },
-        bodyDomains: ["cloudfront.net", "amazonaws.com"],
-        bodyFqdns: ["cdn.jsdelivr.net"],
-      }),
-    ).toEqual([]);
-  });
-});
-
 describe("buildEnrichedTechnologies", () => {
-  it("merges persisted, CPE-promoted, and derived technologies without duplicates", () => {
+  it("merges persisted, additional, and CPE-promoted technologies without duplicates", () => {
     expect(
       buildEnrichedTechnologies({
         persistedTechnologies: ["Amazon Web Services", "Nginx", "Contentful"],
@@ -93,12 +64,6 @@ describe("buildEnrichedTechnologies", () => {
             product: "wordpress",
           },
         ],
-        cspJson: {
-          domains: ["contentful.com", "salesforce.com"],
-          fqdn: ["cdn.segment.com"],
-        },
-        bodyDomains: ["google-analytics.com"],
-        bodyFqdns: ["js.intercomcdn.com"],
       }),
     ).toEqual([
       "Amazon Web Services",
@@ -107,10 +72,6 @@ describe("buildEnrichedTechnologies", () => {
       "Drupal",
       "Next.js",
       "WordPress",
-      "Google Analytics",
-      "Salesforce",
-      "Segment",
-      "Intercom",
     ]);
   });
 });

--- a/lib/server/scans/technology-enrichment.ts
+++ b/lib/server/scans/technology-enrichment.ts
@@ -22,14 +22,6 @@ type TechnologyEvidenceInput = {
   persistedTechnologies: readonly string[];
   additionalTechnologies?: readonly string[];
   cpeEntries: readonly CpeEntry[];
-  cspJson: Record<string, unknown>;
-  bodyDomains: readonly string[];
-  bodyFqdns: readonly string[];
-};
-
-type DomainTechnologyRule = {
-  technologyName: string;
-  domains: readonly string[];
 };
 
 const promotedCpeTechnologyNames = new Map<string, string>([
@@ -43,59 +35,8 @@ const promotedCpeTechnologyNames = new Map<string, string>([
   ["shopify:shopify", "Shopify"],
 ]);
 
-const derivedTechnologyDomainRules: DomainTechnologyRule[] = [
-  {
-    technologyName: "Contentful",
-    domains: ["contentful.com", "ctfassets.net", "ctfapps.net"],
-  },
-  {
-    technologyName: "Google Analytics",
-    domains: ["google-analytics.com", "googletagmanager.com"],
-  },
-  {
-    technologyName: "Salesforce",
-    domains: ["salesforce.com", "force.com", "pardot.com", "exacttarget.com", "salesforceliveagent.com"],
-  },
-  {
-    technologyName: "Segment",
-    domains: ["segment.com"],
-  },
-  {
-    technologyName: "Marketo",
-    domains: ["marketo.net"],
-  },
-  {
-    technologyName: "Intercom",
-    domains: ["intercom.io", "intercomcdn.com"],
-  },
-  {
-    technologyName: "Plausible Analytics",
-    domains: ["plausible.io"],
-  },
-  {
-    technologyName: "Sentry",
-    domains: ["sentry.io"],
-  },
-  {
-    technologyName: "Userflow",
-    domains: ["userflow.com"],
-  },
-  {
-    technologyName: "hCaptcha",
-    domains: ["hcaptcha.com"],
-  },
-  {
-    technologyName: "Pusher",
-    domains: ["pusher.com"],
-  },
-];
-
 function normalizeTechnologyName(value: string) {
   return canonicalizeTechnologyLabel(value).name.trim().toLowerCase();
-}
-
-function normalizeDomain(value: string) {
-  return value.trim().toLowerCase().replace(/\.$/, "");
 }
 
 function appendUnique(technologyNames: string[], seen: Set<string>, nextTechnologyNames: readonly string[]) {
@@ -122,48 +63,6 @@ function getCpeTechnologyKey(entry: CpeEntry) {
   return `${vendor}:${product}`;
 }
 
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-}
-
-function collectEvidenceDomains({ cspJson, bodyDomains, bodyFqdns }: Omit<TechnologyEvidenceInput, "persistedTechnologies" | "cpeEntries">) {
-  const domains = new Set<string>();
-
-  for (const domain of bodyDomains) {
-    const normalized = normalizeDomain(domain);
-
-    if (normalized.length > 0) {
-      domains.add(normalized);
-    }
-  }
-
-  for (const fqdn of bodyFqdns) {
-    const normalized = normalizeDomain(fqdn);
-
-    if (normalized.length > 0) {
-      domains.add(normalized);
-    }
-  }
-
-  for (const domain of readStringArray(cspJson.domains)) {
-    const normalized = normalizeDomain(domain);
-
-    if (normalized.length > 0) {
-      domains.add(normalized);
-    }
-  }
-
-  for (const fqdn of readStringArray(cspJson.fqdn)) {
-    const normalized = normalizeDomain(fqdn);
-
-    if (normalized.length > 0) {
-      domains.add(normalized);
-    }
-  }
-
-  return [...domains];
-}
-
 export function promoteTechnologiesFromCpe(cpeEntries: readonly CpeEntry[]) {
   const promotedTechnologyNames: string[] = [];
   const seen = new Set<string>();
@@ -187,35 +86,10 @@ export function promoteTechnologiesFromCpe(cpeEntries: readonly CpeEntry[]) {
   return promotedTechnologyNames;
 }
 
-export function deriveTechnologiesFromEvidence({
-  cspJson,
-  bodyDomains,
-  bodyFqdns,
-}: Omit<TechnologyEvidenceInput, "persistedTechnologies" | "cpeEntries">) {
-  const evidenceDomains = collectEvidenceDomains({ cspJson, bodyDomains, bodyFqdns });
-  const derivedTechnologyNames: string[] = [];
-  const seen = new Set<string>();
-
-  for (const rule of derivedTechnologyDomainRules) {
-    const matchesRule = evidenceDomains.some((evidenceDomain) => {
-      return rule.domains.some((domain) => evidenceDomain === domain || evidenceDomain.endsWith(`.${domain}`));
-    });
-
-    if (matchesRule) {
-      appendUnique(derivedTechnologyNames, seen, [rule.technologyName]);
-    }
-  }
-
-  return derivedTechnologyNames;
-}
-
 export function buildEnrichedTechnologies({
   persistedTechnologies,
   additionalTechnologies = [],
   cpeEntries,
-  cspJson,
-  bodyDomains,
-  bodyFqdns,
 }: TechnologyEvidenceInput) {
   return buildEnrichedTechnologyDetections({
     persistedTechnologies: persistedTechnologies.map((name) => ({
@@ -227,9 +101,6 @@ export function buildEnrichedTechnologies({
       source: "nuclei" as const,
     })),
     cpeEntries,
-    cspJson,
-    bodyDomains,
-    bodyFqdns,
   }).map((technology) => technology.name);
 }
 
@@ -237,16 +108,10 @@ export function buildEnrichedTechnologyDetections({
   persistedTechnologies,
   additionalTechnologies = [],
   cpeEntries,
-  cspJson,
-  bodyDomains,
-  bodyFqdns,
 }: {
   persistedTechnologies: readonly TechnologyEvidenceItem[];
   additionalTechnologies?: readonly TechnologyEvidenceItem[];
   cpeEntries: readonly CpeEntry[];
-  cspJson: Record<string, unknown>;
-  bodyDomains: readonly string[];
-  bodyFqdns: readonly string[];
 }) {
   const detectionOrder: string[] = [];
   const detectionMap = new Map<string, {
@@ -301,17 +166,6 @@ export function buildEnrichedTechnologyDetections({
     appendEvidence({
       ...canonicalizeTechnologyLabel(technologyName),
       source: "cpe",
-    });
-  }
-
-  for (const technologyName of deriveTechnologiesFromEvidence({
-    cspJson,
-    bodyDomains,
-    bodyFqdns,
-  })) {
-    appendEvidence({
-      ...canonicalizeTechnologyLabel(technologyName),
-      source: "derived",
     });
   }
 

--- a/worker/scan-worker.ts
+++ b/worker/scan-worker.ts
@@ -603,9 +603,6 @@ function buildStoredResultVisibleTechnologies(
     persistedTechnologies: persistedTechnologyNames ?? asStringArray(rawPayload.tech),
     additionalTechnologies: nucleiTechnologyNames,
     cpeEntries,
-    cspJson: toObject(result.cspJson),
-    bodyDomains: Array.isArray(result.bodyDomains) ? result.bodyDomains : [],
-    bodyFqdns: Array.isArray(result.bodyFqdns) ? result.bodyFqdns : [],
   });
 }
 
@@ -1918,9 +1915,6 @@ async function persistHttpxResult(claimedScan: ClaimedScan, payload: HttpxJson, 
   const visibleTechnologies = buildEnrichedTechnologies({
     persistedTechnologies: technologies,
     cpeEntries,
-    cspJson: csp,
-    bodyDomains,
-    bodyFqdns,
   });
   const chain = Array.isArray(payload.chain)
     ? payload.chain.filter((entry): entry is Record<string, unknown> => isObject(entry))


### PR DESCRIPTION
## Summary
- add custom Wappalyzer fingerprints for the former domain-derived technology rules
- add Plausible Analytics metadata for the custom fingerprint catalog
- remove Stackray read-time and worker-time domain-to-technology derivation
- tighten Google Analytics detection to GA-specific domains / gtag IDs instead of any googletagmanager.com reference

## Verification
- pnpm test lib/server/scans/technology-enrichment.test.ts lib/server/scans/read-service.test.ts worker/scan-worker.test.ts lib/server/scans/technology-display.test.ts
- pnpm typecheck
- pnpm lint