### PR TITLE
feat(scans): match TanStack bundle markers

### DIFF
--- a/docs/technology-detection.md
+++ b/docs/technology-detection.md
@@ -94,6 +94,23 @@ That means a custom fingerprint can work in both paths, but only if the needed e
 
 Do not assume that adding a `scripts` rule to the custom fingerprint file is enough for modern SPA bundles. If `httpx` does not collect the bundle body for that scan path, Wappalyzer cannot match it.
 
+### What `-tdh` can match from custom fingerprints
+
+The headless `-tdh` pass has a broader evidence surface than the primary `-td` pass. In the Stackray `httpx` fork, custom fingerprints can use these rule shapes against browser-collected evidence:
+
+- `html`: rendered page HTML from the browser.
+- `js`: browser-evaluated JavaScript globals and property paths.
+- `dom`: rendered DOM selectors, text, attributes, and selected DOM properties.
+- `cookies`: browser cookies after the page loads.
+- `headers`: same-origin response headers observed by the browser.
+- `scriptSrc`: URLs of scripts observed by the browser.
+- `scripts`: same-origin script bodies collected from browser network responses or fetched fallback script URLs.
+- `css`: same-origin stylesheet bodies observed by the browser.
+
+Use these fields when the detection can be expressed as a pattern over collected evidence. For example, a framework marker inside a loaded JavaScript bundle belongs in `scripts`, not only in `html`.
+
+The fork also contains hard-coded headless heuristics for cases that are not cleanly expressed as a single fingerprint field, such as scoring multiple React runtime symbols, checking private React DOM property prefixes, or combining Vite asset and modulepreload signals. Keep those in the fork unless equivalent custom fingerprints are proven with `httpx` tests and real `payload.tech` output.
+
 ## When to change which layer
 
 ### Add only metadata

--- a/lib/server/scans/custom-wappalyzer-fingerprints.json
+++ b/lib/server/scans/custom-wappalyzer-fingerprints.json
@@ -96,6 +96,9 @@
       "html": [
         "\\$_tsr\\.router[\\s\\S]{0,1000}tsr-scroll-restoration|tsr-scroll-restoration[\\s\\S]{0,1000}\\$_tsr\\.router"
       ],
+      "scripts": [
+        "\\$_tsr\\.router[\\s\\S]{0,1000}tsr-scroll-restoration|tsr-scroll-restoration[\\s\\S]{0,1000}\\$_tsr\\.router"
+      ],
       "implies": []
     },
     "TanStack Start": {
@@ -104,6 +107,9 @@
         12
       ],
       "html": [
+        "\\$_tsr\\.router[\\s\\S]{0,1000}tsr-stream-barrier|tsr-stream-barrier[\\s\\S]{0,1000}\\$_tsr\\.router"
+      ],
+      "scripts": [
         "\\$_tsr\\.router[\\s\\S]{0,1000}tsr-stream-barrier|tsr-stream-barrier[\\s\\S]{0,1000}\\$_tsr\\.router"
       ],
       "implies": [


### PR DESCRIPTION
## Summary
- add TanStack Router and TanStack Start `scripts` fingerprint rules so `-tdh` can match same-origin JS bundle markers
- document the custom fingerprint fields available from headless technology detection

## Tests
- `pnpm exec vitest run worker/scan-worker.test.ts lib/server/scans/technology-metadata-catalog.test.ts`