### PR TITLE
ci: harden scanner pin automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           changed_files="$(git diff --name-only "${base}" "${head}")"
           printf '%s\n' "${changed_files}"
 
-          if printf '%s\n' "${changed_files}" | grep -Eq '^(worker/|scripts/update-scanner-pins\.ts$|docker-compose\.dev\.yml$|package\.json$|pnpm-lock\.yaml$|lib/server/scans/custom-wappalyzer-fingerprints\.json$|lib/server/scans/custom-technology-metadata\.json$)'; then
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(worker/|scripts/update-scanner-pins\.ts$|docker-compose\.dev\.yml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/ci\.yml$|lib/server/scans/custom-wappalyzer-fingerprints\.json$|lib/server/scans/custom-technology-metadata\.json$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -135,7 +135,78 @@ jobs:
 
       - name: Build worker scanner image
         if: steps.changes.outputs.changed == 'true'
-        run: docker build -f worker/Dockerfile .
+        run: docker build -f worker/Dockerfile -t stackray-worker-scanner-smoke:${{ github.sha }} .
+
+      - name: Smoke test pinned scanner image
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          docker run --rm stackray-worker-scanner-smoke:${{ github.sha }} sh -euxc '
+            cat <<'"'"'NODE'"'"' > /tmp/stackray-smoke-server.mjs
+          import http from "node:http";
+
+          const html = `<!doctype html>
+          <html>
+            <head><title>Stackray scanner smoke</title></head>
+            <body>
+              <script src="https://js.stripe.com/v3"></script>
+              <script>window.stripePublicKey = "pk_test_stackrayscanner123";</script>
+            </body>
+          </html>`;
+
+          const server = http.createServer((_request, response) => {
+            response.writeHead(200, { "content-type": "text/html" });
+            response.end(html);
+          });
+
+          server.listen(48765, "127.0.0.1");
+          NODE
+
+            node /tmp/stackray-smoke-server.mjs &
+            server_pid="$!"
+            trap "kill ${server_pid}" EXIT
+
+            for attempt in 1 2 3 4 5; do
+              if node -e "fetch('"'"'http://127.0.0.1:48765'"'"').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"; then
+                break
+              fi
+              sleep 1
+            done
+
+            httpx \
+              -silent \
+              -json \
+              -td \
+              -cff /app/lib/server/scans/custom-wappalyzer-fingerprints.json \
+              -u http://127.0.0.1:48765 \
+              -retries 0 \
+              -timeout 5 \
+              -duc > /tmp/httpx-smoke.jsonl
+
+            node <<'"'"'NODE'"'"'
+          const { readFileSync } = await import("node:fs");
+
+          const rows = readFileSync("/tmp/httpx-smoke.jsonl", "utf8")
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => JSON.parse(line));
+
+          if (rows.length !== 1) {
+            throw new Error(`Expected one httpx JSONL row, got ${rows.length}`);
+          }
+
+          const [row] = rows;
+          if (row.status_code !== 200) {
+            throw new Error(`Expected status_code 200, got ${row.status_code}`);
+          }
+          if (!Array.isArray(row.tech) || !row.tech.includes("Stripe")) {
+            throw new Error(`Expected detected Stripe technology, got ${JSON.stringify(row.tech)}`);
+          }
+          if ("TechnologyDetails" in row || "technology_details" in row) {
+            throw new Error("Internal technology details leaked into Stackray JSONL output");
+          }
+          NODE
+          '
 
       - name: Skip worker scanner image build
         if: steps.changes.outputs.changed != 'true'

--- a/.github/workflows/trusted-scanner-pin-auto-merge.yml
+++ b/.github/workflows/trusted-scanner-pin-auto-merge.yml
@@ -1,0 +1,147 @@
+name: Trusted scanner pin auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  merge-scanner-pin-update:
+    name: Merge trusted scanner pin update
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'automation/update-scanner-pins' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate and merge trusted scanner pin PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TRUSTED_AUTHOR: CarlosCommits
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pr_json="$(gh pr list \
+            --repo "${REPOSITORY}" \
+            --state open \
+            --head "automation/update-scanner-pins" \
+            --json number,title,isDraft,author,headRefName,headRefOid,baseRefName,statusCheckRollup \
+            --jq '.[0]')"
+
+          if [ -z "${pr_json}" ] || [ "${pr_json}" = "null" ]; then
+            echo "No open scanner pin update PR found."
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.number' <<<"${pr_json}")"
+          title="$(jq -r '.title' <<<"${pr_json}")"
+          is_draft="$(jq -r '.isDraft' <<<"${pr_json}")"
+          author="$(jq -r '.author.login' <<<"${pr_json}")"
+          head_ref="$(jq -r '.headRefName' <<<"${pr_json}")"
+          head_sha="$(jq -r '.headRefOid' <<<"${pr_json}")"
+          base_ref="$(jq -r '.baseRefName' <<<"${pr_json}")"
+
+          if [ -n "${WORKFLOW_RUN_PR_NUMBER}" ] && [ "${pr_number}" != "${WORKFLOW_RUN_PR_NUMBER}" ]; then
+            echo "Refusing to merge PR #${pr_number}: workflow_run was for PR #${WORKFLOW_RUN_PR_NUMBER}."
+            exit 1
+          fi
+          if [ "${title}" != "chore: update scanner pins" ]; then
+            echo "Refusing to merge PR #${pr_number}: unexpected title '${title}'."
+            exit 1
+          fi
+          if [ "${author}" != "${TRUSTED_AUTHOR}" ]; then
+            echo "Refusing to merge PR #${pr_number}: unexpected author '${author}'."
+            exit 1
+          fi
+          if [ "${is_draft}" != "false" ]; then
+            echo "Refusing to merge PR #${pr_number}: PR is a draft."
+            exit 1
+          fi
+          if [ "${head_ref}" != "automation/update-scanner-pins" ] || [ "${base_ref}" != "main" ]; then
+            echo "Refusing to merge PR #${pr_number}: unexpected ${head_ref} -> ${base_ref}."
+            exit 1
+          fi
+          if [ "${head_sha}" != "${WORKFLOW_RUN_HEAD_SHA}" ]; then
+            echo "Refusing to merge PR #${pr_number}: head SHA ${head_sha} does not match successful workflow run ${WORKFLOW_RUN_HEAD_SHA}."
+            exit 1
+          fi
+
+          unexpected_files="$(gh pr diff "${pr_number}" --repo "${REPOSITORY}" --name-only | awk '
+            $0 != "package.json" &&
+            $0 != "lib/version.ts" &&
+            $0 != "worker/scanner-pins.json" &&
+            $0 != "worker/Dockerfile" &&
+            $0 != "worker/Dockerfile.dev" {
+              print
+            }
+          ')"
+          if [ -n "${unexpected_files}" ]; then
+            echo "Refusing to merge PR #${pr_number}: unexpected files changed:"
+            printf '%s\n' "${unexpected_files}"
+            exit 1
+          fi
+
+          unexpected_patch_lines="$(gh pr diff "${pr_number}" --repo "${REPOSITORY}" --patch | awk '
+            /^diff --git / {
+              file = $3
+              sub(/^a\//, "", file)
+              next
+            }
+            /^@@ / || /^---/ || /^\+\+\+ / {
+              next
+            }
+            /^[+-]/ {
+              if (file == "package.json" && $0 ~ /^[+-]  "version": "[0-9]+\.[0-9]+\.[0-9]+",$/) {
+                next
+              }
+              if (file == "lib/version.ts" && $0 ~ /^[+-]export const APP_VERSION = "[0-9]+\.[0-9]+\.[0-9]+"$/) {
+                next
+              }
+              if (file == "worker/scanner-pins.json" && $0 ~ /^[+-]    "ref": "[0-9a-f]{40}"[,]?$/) {
+                next
+              }
+              if (file == "worker/scanner-pins.json" && $0 ~ /^[+-]    "version": "v[0-9]+\.[0-9]+\.[0-9]+"$/) {
+                next
+              }
+              if ((file == "worker/Dockerfile" || file == "worker/Dockerfile.dev") && $0 ~ /^[+-]ARG HTTPX_REF=[0-9a-f]{40}$/) {
+                next
+              }
+              if ((file == "worker/Dockerfile" || file == "worker/Dockerfile.dev") && $0 ~ /^[+-]ARG NUCLEI_VERSION=v[0-9]+\.[0-9]+\.[0-9]+$/) {
+                next
+              }
+              if ((file == "worker/Dockerfile" || file == "worker/Dockerfile.dev") && $0 ~ /^[+-]ARG NUCLEI_TEMPLATES_REF=[0-9a-f]{40}$/) {
+                next
+              }
+              print file ":" $0
+            }
+          ')"
+          if [ -n "${unexpected_patch_lines}" ]; then
+            echo "Refusing to merge PR #${pr_number}: unexpected scanner pin patch lines:"
+            printf '%s\n' "${unexpected_patch_lines}"
+            exit 1
+          fi
+
+          for check_name in "Quality" "Scanner Docker build" "E2E smoke"; do
+            conclusion="$(jq -r --arg name "${check_name}" '
+              [.statusCheckRollup[] | select(.name == $name) | .conclusion] | first // ""
+            ' <<<"${pr_json}")"
+            if [ "${conclusion}" != "SUCCESS" ]; then
+              echo "Refusing to merge PR #${pr_number}: ${check_name} conclusion is '${conclusion}'."
+              exit 1
+            fi
+          done
+
+          gh pr merge "${pr_number}" --repo "${REPOSITORY}" --merge --delete-branch --match-head-commit "${head_sha}"

--- a/.github/workflows/update-scanner-pins.yml
+++ b/.github/workflows/update-scanner-pins.yml
@@ -61,13 +61,8 @@ jobs:
             worker/Dockerfile
             worker/Dockerfile.dev
 
-      # TODO: Re-enable this when repository auto-merge is available.
-      # Private repos without the required GitHub plan cannot enable the
-      # repository-level "Allow auto-merge" setting. Until then, scanner update
-      # PRs are validated here and merged manually.
-      #
-      # - name: Enable pull request auto-merge
-      #   if: steps.cpr.outputs.pull-request-number != ''
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash
+      # The trusted scanner-pin auto-merge workflow handles merging after the
+      # created PR passes CI. Repository-level auto-merge and branch protection
+      # are unavailable for the current private repository plan, so that workflow
+      # uses explicit branch, author, file, semantic diff, check, and head-SHA
+      # gates before running a direct merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,9 @@ The app is intentionally not containerized for local development. Keeping it on 
 - `nuclei` is installed from the pinned release tag
 - nuclei templates are cloned at the pinned `projectdiscovery/nuclei-templates` commit and then overlaid with `worker/nuclei-templates`
 
-Run `pnpm scanners:update` to refresh the pins without changing the Stackray version. Run `pnpm scanners:update:patch` to refresh the pins and bump the Stackray patch version. The scheduled `Update scanner pins` GitHub Action does the patch bump automatically, validates the result, and opens a PR.
+Run `pnpm scanners:update` to refresh the pins without changing the Stackray version. Run `pnpm scanners:update:patch` to refresh the pins and bump the Stackray patch version. The scheduled `Update scanner pins` GitHub Action does the patch bump automatically and opens a PR.
 
-For now, scanner update PRs must be merged manually because GitHub auto-merge is unavailable for the current private repository settings. When the repository becomes public, or the account/repo supports auto-merge for private repositories, re-enable the commented auto-merge step in `.github/workflows/update-scanner-pins.yml`.
+Scanner update PRs are validated by the standard `CI` workflow. After `Quality`, `Scanner Docker build`, and `E2E smoke` pass, `.github/workflows/trusted-scanner-pin-auto-merge.yml` may merge the trusted `automation/update-scanner-pins` PR directly. That workflow exists because repository-level GitHub auto-merge, branch protection, and rulesets are unavailable for the current private repository plan; it compensates with branch, author, file, semantic diff, check, and head-SHA gates.
 
 Use `pnpm release` from a clean, up-to-date `main` checkout for a manual Stackray patch release. The release command bumps the app version, commits and pushes the release commit, waits for the `CI` workflow to pass on that exact commit, then creates the matching annotated tag and GitHub Release. Pass `major`, `minor`, `patch`, or an explicit version when needed, for example `pnpm release minor` or `pnpm release 1.2.3`.
 

--- a/docs/technology-detection.md
+++ b/docs/technology-detection.md
@@ -72,7 +72,8 @@ The fork currently lives at `CarlosCommits/httpx`, branch `dev`. The pin update 
 1. change and push the `httpx` fork
 2. the `Notify Stackray scanner update` workflow in `httpx` dispatches Stackray
 3. Stackray's `Update scanner pins` workflow opens a scanner-pin PR
-4. review and merge the scanner-pin PR
+4. Stackray CI validates the pin PR, including the real worker scanner image smoke test
+5. the trusted scanner-pin auto-merge workflow merges the PR only when the branch, author, file list, semantic diff, checks, and head SHA match the expected automation output
 
 The cross-repo dispatch requires the `STACKRAY_DISPATCH_TOKEN` secret in the `CarlosCommits/httpx` repository.
 
@@ -206,8 +207,8 @@ Use this checklist.
 7. Update scanner pins.
    - Push the `httpx` fork branch.
    - Let the Stackray scanner-pin workflow create a PR.
-   - Review the PR to confirm it only updates scanner pin/version files.
-   - Merge it after validation.
+   - Confirm CI passes if you need to review the update manually.
+   - The trusted scanner-pin auto-merge workflow should merge routine pin/version-only PRs after validation.
 
 ## Current TanStack example
 


### PR DESCRIPTION
## Summary
- Run a real worker-image smoke test that exercises the pinned httpx binary, JSONL output, Stackray custom fingerprints, and internal field filtering.
- Add a trusted scanner-pin auto-merge workflow gated by branch, author, allowed files, semantic diff checks, CI check conclusions, and exact head SHA matching.
- Update docs/comments to describe the custom auto-merge path used while private-repo branch protection/auto-merge are unavailable.

## Verification
- YAML parse for changed workflows
- LSP diagnostics for .github/workflows
- git diff --check
- semantic diff allowlist dry run against Stackray PR #23
- embedded Node snippet syntax checks
- pnpm lint
- pnpm typecheck
- pnpm test (401 passed)
- pnpm build
- docker build -f worker/Dockerfile -t stackray-worker-scanner-smoke:local .
- worker image httpx JSONL smoke test
- Oracle/security/QA reviews passed after hardening fixes