### PR TITLE
chore: update scanner pins

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,2 +1,2 @@
 // Single source of truth - keep this in sync with package.json.
-export const APP_VERSION = "0.1.6"
+export const APP_VERSION = "0.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackray",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -14,7 +14,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.8.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=240597c8533fde9bb92c26e4673235029a9725cd
+ARG NUCLEI_TEMPLATES_REF=da3ba284f338c2dadbfc9c98c3c26fb8d0ce1cf9
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN git clone --filter=blob:none "${NUCLEI_TEMPLATES_REPO}" /opt/nuclei-templates \

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -14,7 +14,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.8.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=240597c8533fde9bb92c26e4673235029a9725cd
+ARG NUCLEI_TEMPLATES_REF=da3ba284f338c2dadbfc9c98c3c26fb8d0ce1cf9
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN git clone --filter=blob:none "${NUCLEI_TEMPLATES_REPO}" /opt/nuclei-templates \

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -13,6 +13,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "240597c8533fde9bb92c26e4673235029a9725cd"
+    "ref": "da3ba284f338c2dadbfc9c98c3c26fb8d0ce1cf9"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, and nuclei-template inputs used by the worker image.
- Bump Stackray patch version so deployments can detect the new tested scanner bundle.

`httpx: d979980 -> d979980; nuclei: v3.8.0 -> v3.8.0; nuclei-templates: 240597c -> da3ba28`

Release version: `v0.1.7`