### PR TITLE
fix recovered headless title promotion

### DIFF
--- a/worker/scan-worker.test.ts
+++ b/worker/scan-worker.test.ts
@@ -510,6 +510,62 @@ describe("buildHeadlessMetadataPromotion", () => {
     });
   });
 
+  it("promotes the headless title when headless recovers a blocked document", () => {
+    expect(
+      buildHeadlessMetadataPromotion(
+        {
+          statusCode: 403,
+          title: "Access Denied",
+          faviconMmh3: null,
+          faviconMd5: null,
+          faviconUrl: null,
+          faviconPath: null,
+        },
+        {
+          statusCode: 200,
+          url: "https://www.redbull.com/us-en",
+        },
+        "Red Bull Energy Drink - Gives You Wiiings",
+        {
+          faviconMmh3: null,
+          faviconMd5: null,
+          faviconUrl: null,
+          faviconPath: null,
+        },
+      ),
+    ).toEqual({
+      statusCode: 200,
+      finalUrl: "https://www.redbull.com/us-en",
+      title: "Red Bull Energy Drink - Gives You Wiiings",
+    });
+  });
+
+  it("keeps existing titles when the headless pass does not recover a blocked document", () => {
+    expect(
+      buildHeadlessMetadataPromotion(
+        {
+          statusCode: 200,
+          title: "Existing Title",
+          faviconMmh3: null,
+          faviconMd5: null,
+          faviconUrl: null,
+          faviconPath: null,
+        },
+        {
+          statusCode: 200,
+          url: "https://example.com/",
+        },
+        "Different Rendered Title",
+        {
+          faviconMmh3: null,
+          faviconMd5: null,
+          faviconUrl: null,
+          faviconPath: null,
+        },
+      ),
+    ).toEqual({});
+  });
+
   it("keeps existing favicon fields instead of replacing them from headless enrichment", () => {
     expect(
       buildHeadlessMetadataPromotion(

--- a/worker/scan-worker.ts
+++ b/worker/scan-worker.ts
@@ -1286,16 +1286,27 @@ function shouldPromoteHeadlessDocumentStatus(
   return result.statusCode === null || result.statusCode >= 400;
 }
 
-function shouldRecoverHeadlessTitle(result: { title: string | null }) {
+function shouldRecoverHeadlessTitle(
+  result: { statusCode: number | null; title: string | null },
+  observation: HeadlessDocumentObservation | null,
+) {
+  if (shouldPromoteHeadlessDocumentStatus(result, observation)) {
+    return true;
+  }
+
   return !result.title || result.title === "Vercel Security Checkpoint";
 }
 
-function shouldPromoteHeadlessTitle(result: { title: string | null }, headlessTitle: string | null) {
+function shouldPromoteHeadlessTitle(
+  result: { statusCode: number | null; title: string | null },
+  observation: HeadlessDocumentObservation | null,
+  headlessTitle: string | null,
+) {
   if (!headlessTitle) {
     return false;
   }
 
-  return shouldRecoverHeadlessTitle(result);
+  return shouldRecoverHeadlessTitle(result, observation);
 }
 
 export function buildHeadlessMetadataPromotion(
@@ -1328,7 +1339,7 @@ export function buildHeadlessMetadataPromotion(
     }
   }
 
-  if (shouldPromoteHeadlessTitle(result, headlessTitle)) {
+  if (shouldPromoteHeadlessTitle(result, promotedObservation, headlessTitle)) {
     metadataPromotion.title = headlessTitle ?? undefined;
   }
 


### PR DESCRIPTION
## Summary
- promote the headless browser title when headless recovers a blocked/error document to a successful document
- keep existing successful-result titles unless the existing Vercel recovery case applies
- add regression coverage for an Access Denied title recovered by headless metadata

## Root cause
Stackray only promoted headless titles when the stored title was empty or exactly `Vercel Security Checkpoint`. Sites like Red Bull returned an HTTP title of `Access Denied`, while `httpx -tdh -title` correctly emitted the rendered browser title. The Stackray promotion guard blocked that better title.

## Validation
- `pnpm test -- worker/scan-worker.test.ts`
- `pnpm typecheck`