### PR TITLE
chore: update scanner pins

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,2 +1,2 @@
 // Single source of truth - keep this in sync with package.json.
-export const APP_VERSION = "0.1.9"
+export const APP_VERSION = "0.1.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackray",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.8.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=b47728a71baac09da5592e1e5faa548fd8bcc659
+ARG NUCLEI_TEMPLATES_REF=068cc340fe9ae954feac3e1669de9f9d2853f43b
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.8.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=b47728a71baac09da5592e1e5faa548fd8bcc659
+ARG NUCLEI_TEMPLATES_REF=068cc340fe9ae954feac3e1669de9f9d2853f43b
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -17,6 +17,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "b47728a71baac09da5592e1e5faa548fd8bcc659"
+    "ref": "068cc340fe9ae954feac3e1669de9f9d2853f43b"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Bump Stackray patch version so deployments can detect the new tested scanner bundle.

`httpx: c32d05b -> c32d05b; nuclei: v3.8.0 -> v3.8.0; subfinder: v2.14.0 -> v2.14.0; nuclei-templates: b47728a -> 068cc34`

Release version: `v0.1.10`