### PR TITLE
feat: improve runs and targets search

### DIFF
--- a/components/runs/runs-client.test.tsx
+++ b/components/runs/runs-client.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { fireEvent, render, screen, waitFor, act } from "@testing-library/react"
 
 import type { RunsRow } from "./types"
@@ -26,6 +26,11 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockFetch.mockReset()
+  window.sessionStorage.clear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 const mockRows: RunsRow[] = [
@@ -217,6 +222,60 @@ describe("RunsClient", () => {
     })
 
     expect(screen.queryByText(/run/)).not.toBeInTheDocument()
+    expect(window.sessionStorage.getItem("stackray:runs-table:v1")).toBeNull()
+  })
+
+  it("does not fetch a stale search after filters are cleared before debounce settles", async () => {
+    vi.useFakeTimers()
+
+    render(<RunsClient initialRows={mockRows} initialNextCursor={null} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/search by scan id, creator, technology, or target/i), {
+      target: { value: "stale-search" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_MS + 50)
+      await Promise.resolve()
+    })
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(window.sessionStorage.getItem("stackray:runs-table:v1")).toBeNull()
+  })
+
+  it("restores filters, search, and sort from sessionStorage", async () => {
+    window.sessionStorage.setItem("stackray:runs-table:v1", JSON.stringify({
+      search: "api.example",
+      status: "running",
+      source: "api",
+      sortOrder: "oldest",
+    }))
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: [mockRows[1]], nextCursor: null }),
+    })
+
+    render(<RunsClient initialRows={mockRows} initialNextCursor={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("api.example")).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 50))
+    })
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+    })
+
+    const requestUrl = new URL(String(mockFetch.mock.calls.at(-1)?.[0]), "http://localhost")
+    expect(requestUrl.searchParams.get("q")).toBe("api.example")
+    expect(requestUrl.searchParams.get("status")).toBe("running")
+    expect(requestUrl.searchParams.get("source")).toBe("api")
+    expect(requestUrl.searchParams.get("sort")).toBe("oldest")
   })
 
   it("displays rows in default newest-first order", async () => {

--- a/components/runs/runs-client.tsx
+++ b/components/runs/runs-client.tsx
@@ -28,6 +28,53 @@ interface RunsPageResponse {
 
 const DEBOUNCE_MS = 275
 const PAGE_SIZE = 50
+const RUNS_TABLE_STORAGE_KEY = "stackray:runs-table:v1"
+const RUNS_STATUS_VALUES = new Set<RunsStatusValue>(["queued", "running", "completed", "failed", "cancelled"])
+const RUNS_SOURCE_VALUES = new Set<RunsSourceValue>(["ui", "cli", "api", "system"])
+
+interface StoredRunsTableState extends FilterState {
+  sortOrder: SortOrder
+}
+
+function isStoredRunsTableState(value: unknown): value is StoredRunsTableState {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const state = value as Partial<Record<keyof StoredRunsTableState, unknown>>
+
+  return typeof state.search === "string"
+    && (state.status === "all" || (typeof state.status === "string" && RUNS_STATUS_VALUES.has(state.status as RunsStatusValue)))
+    && (state.source === "all" || (typeof state.source === "string" && RUNS_SOURCE_VALUES.has(state.source as RunsSourceValue)))
+    && (state.sortOrder === "newest" || state.sortOrder === "oldest")
+}
+
+function readStoredRunsTableState(): StoredRunsTableState | null {
+  try {
+    const rawValue = window.sessionStorage.getItem(RUNS_TABLE_STORAGE_KEY)
+
+    if (!rawValue) {
+      return null
+    }
+
+    const parsedValue: unknown = JSON.parse(rawValue)
+
+    return isStoredRunsTableState(parsedValue) ? parsedValue : null
+  } catch {
+    return null
+  }
+}
+
+function writeStoredRunsTableState(state: StoredRunsTableState) {
+  window.sessionStorage.setItem(RUNS_TABLE_STORAGE_KEY, JSON.stringify(state))
+}
+
+function isDefaultRunsTableState(state: StoredRunsTableState): boolean {
+  return state.search === ""
+    && state.status === "all"
+    && state.source === "all"
+    && state.sortOrder === "newest"
+}
 
 async function fetchRunsPage(
   search: string,
@@ -71,10 +118,52 @@ export function RunsClient({
 
   const [serverQueryKey, setServerQueryKey] = useState<string>("")
   const isUsingServerData = serverQueryKey !== ""
+  const [hasRestoredSessionState, setHasRestoredSessionState] = useState(false)
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const activeQueryKeyRef = useRef("")
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search)
+
+  const clearSearchDebounce = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    const storedState = readStoredRunsTableState()
+
+    if (storedState) {
+      setFilters({
+        search: storedState.search,
+        status: storedState.status,
+        source: storedState.source,
+      })
+      setDebouncedSearch(storedState.search)
+      setSortOrder(storedState.sortOrder)
+    }
+
+    setHasRestoredSessionState(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hasRestoredSessionState) {
+      return
+    }
+
+    const state = {
+      ...filters,
+      sortOrder,
+    }
+
+    if (isDefaultRunsTableState(state)) {
+      window.sessionStorage.removeItem(RUNS_TABLE_STORAGE_KEY)
+      return
+    }
+
+    writeStoredRunsTableState(state)
+  }, [filters, hasRestoredSessionState, sortOrder])
 
   // Update debounced search when filter.search changes
   useEffect(() => {
@@ -191,11 +280,15 @@ export function RunsClient({
   const displayCount = isUsingServerData && !hasMore ? rows.length : undefined
 
   const handleClearFilters = () => {
+    window.sessionStorage.removeItem(RUNS_TABLE_STORAGE_KEY)
+    clearSearchDebounce()
     setFilters({
       search: "",
       status: "all",
       source: "all",
     })
+    setDebouncedSearch("")
+    setSortOrder("newest")
   }
 
   const toggleSortOrder = () => {

--- a/components/targets/targets-client.test.tsx
+++ b/components/targets/targets-client.test.tsx
@@ -18,6 +18,7 @@ beforeAll(async () => {
 })
 
 beforeEach(() => {
+  window.sessionStorage.clear()
   vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
     const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url, "http://localhost")
     return {
@@ -267,6 +268,90 @@ describe("targets client", () => {
     const table = await screen.findByRole("table")
     expect(screen.queryByText(new RegExp(`\\d+ ${TARGETS_RESULT_COUNT_LABEL}`))).not.toBeInTheDocument()
     expect(within(table).getByText("tpss.coop")).toBeInTheDocument()
+    expect(window.sessionStorage.getItem("stackray:targets-table:v1")).toBeNull()
+  })
+
+  it("does not fetch a stale search after filters are cleared before debounce settles", async () => {
+    vi.useFakeTimers()
+
+    await renderTargetsClient()
+
+    const mockedFetch = vi.mocked(fetch)
+    mockedFetch.mockClear()
+
+    fireEvent.change(screen.getByPlaceholderText(TARGETS_FILTER_PLACEHOLDER), {
+      target: { value: "stale-search" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: TARGETS_CLEAR_FILTERS_BUTTON_LABEL }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+      await Promise.resolve()
+    })
+
+    expect(mockedFetch).not.toHaveBeenCalled()
+    expect(window.sessionStorage.getItem("stackray:targets-table:v1")).toBeNull()
+  })
+
+  it("restores filters from sessionStorage and refetches targets", async () => {
+    window.sessionStorage.setItem("stackray:targets-table:v1", JSON.stringify({
+      q: "blog",
+      technology: ["wordpress"],
+      cdn: ["cloudflare"],
+      server: [],
+      plugin: ["jetpack"],
+      theme: [],
+      cpe: [],
+      statusCode: ["200"],
+      from: "2026-03-21",
+      to: "2026-03-22",
+    }))
+
+    await renderTargetsClient()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("blog")).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled()
+    })
+
+    const mockedFetch = vi.mocked(fetch)
+    const requestUrl = new URL(String(mockedFetch.mock.calls.at(-1)?.[0]), "http://localhost")
+
+    expect(requestUrl.searchParams.get("q")).toBe("blog")
+    expect(requestUrl.searchParams.get("technology")).toBe("wordpress")
+    expect(requestUrl.searchParams.get("cdn")).toBe("cloudflare")
+    expect(requestUrl.searchParams.get("plugin")).toBe("jetpack")
+    expect(requestUrl.searchParams.get("statusCode")).toBe("200")
+    expect(requestUrl.searchParams.get("from")).toBe("2026-03-21")
+    expect(requestUrl.searchParams.get("to")).toBe("2026-03-22")
+  })
+
+  it("keeps explicit URL filters ahead of stored session state", async () => {
+    window.sessionStorage.setItem("stackray:targets-table:v1", JSON.stringify({
+      q: "blog",
+      technology: [],
+      cdn: [],
+      server: [],
+      plugin: [],
+      theme: [],
+      cpe: [],
+      statusCode: [],
+      from: "",
+      to: "",
+    }))
+
+    await renderTargetsClient("plugin=jetpack")
+
+    expect(screen.queryByDisplayValue("blog")).not.toBeInTheDocument()
+    expect(screen.getByText("Plugin:")).toBeInTheDocument()
+    expect(screen.getByText("Jetpack")).toBeInTheDocument()
+    expect(JSON.parse(window.sessionStorage.getItem("stackray:targets-table:v1") ?? "{}")).toMatchObject({
+      plugin: ["jetpack"],
+      q: "",
+    })
   })
 
   it("renders the filtered empty state when seeded with an already-empty query result", async () => {

--- a/components/targets/targets-client.tsx
+++ b/components/targets/targets-client.tsx
@@ -35,6 +35,68 @@ interface TargetsPageResponse {
 }
 
 const DEBOUNCE_MS = 275
+const TARGETS_TABLE_STORAGE_KEY = "stackray:targets-table:v1"
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function isStoredTargetsTableState(value: unknown): value is TargetsFilterState {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const state = value as Partial<Record<keyof TargetsFilterState, unknown>>
+
+  return typeof state.q === "string"
+    && isStringArray(state.technology)
+    && isStringArray(state.cdn)
+    && isStringArray(state.server)
+    && isStringArray(state.plugin)
+    && isStringArray(state.theme)
+    && isStringArray(state.cpe)
+    && isStringArray(state.statusCode)
+    && typeof state.from === "string"
+    && typeof state.to === "string"
+}
+
+function readStoredTargetsTableState(): TargetsFilterState | null {
+  try {
+    const rawValue = window.sessionStorage.getItem(TARGETS_TABLE_STORAGE_KEY)
+
+    if (!rawValue) {
+      return null
+    }
+
+    const parsedValue: unknown = JSON.parse(rawValue)
+
+    return isStoredTargetsTableState(parsedValue) ? parsedValue : null
+  } catch {
+    return null
+  }
+}
+
+function isDefaultTargetsTableState(state: TargetsFilterState): boolean {
+  return state.q === ""
+    && state.technology.length === 0
+    && state.cdn.length === 0
+    && state.server.length === 0
+    && state.plugin.length === 0
+    && state.theme.length === 0
+    && state.cpe.length === 0
+    && state.statusCode.length === 0
+    && state.from === ""
+    && state.to === ""
+}
+
+function writeStoredTargetsTableState(state: TargetsFilterState) {
+  if (isDefaultTargetsTableState(state)) {
+    window.sessionStorage.removeItem(TARGETS_TABLE_STORAGE_KEY)
+    return
+  }
+
+  window.sessionStorage.setItem(TARGETS_TABLE_STORAGE_KEY, JSON.stringify(state))
+}
 
 function toDateInputValue(value: string | null): string {
   if (!value) {
@@ -94,13 +156,7 @@ export function TargetsClient({
   initialNextCursor,
   initialQuery,
 }: TargetsClientProps) {
-  const [rows, setRows] = useState(initialRows)
-  const [cursor, setCursor] = useState<string | null>(initialNextCursor)
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingMore, setIsLoadingMore] = useState(false)
-  const [hasMore, setHasMore] = useState(initialNextCursor !== null)
-  const [error, setError] = useState<string | null>(null)
-  const [filters, setFilters] = useState<TargetsFilterState>({
+  const initialFilters = useMemo<TargetsFilterState>(() => ({
     q: initialQuery?.q ?? "",
     technology: initialQuery?.technology ?? [],
     cdn: initialQuery?.cdn ?? [],
@@ -111,10 +167,44 @@ export function TargetsClient({
     statusCode: initialQuery?.statusCode.map(String) ?? [],
     from: toDateInputValue(initialQuery?.from ?? null),
     to: toDateInputValue(initialQuery?.to ?? null),
-  })
+  }), [initialQuery])
+  const [rows, setRows] = useState(initialRows)
+  const [cursor, setCursor] = useState<string | null>(initialNextCursor)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(initialNextCursor !== null)
+  const [error, setError] = useState<string | null>(null)
+  const [filters, setFilters] = useState<TargetsFilterState>(initialFilters)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const activeQueryKeyRef = useRef("")
   const [debouncedSearch, setDebouncedSearch] = useState(filters.q)
+  const [hasRestoredSessionState, setHasRestoredSessionState] = useState(false)
+
+  const clearSearchDebounce = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    const storedState = readStoredTargetsTableState()
+
+    if (isDefaultTargetsTableState(initialFilters) && storedState) {
+      setFilters(storedState)
+      setDebouncedSearch(storedState.q)
+    }
+
+    setHasRestoredSessionState(true)
+  }, [initialFilters])
+
+  useEffect(() => {
+    if (!hasRestoredSessionState) {
+      return
+    }
+
+    writeStoredTargetsTableState(filters)
+  }, [filters, hasRestoredSessionState])
 
   useEffect(() => {
     if (debounceTimerRef.current) {
@@ -266,6 +356,8 @@ export function TargetsClient({
   const displayCount = hasActiveFilters && isShowingSettledRows && !isLoading && !hasMore ? rows.length : undefined
 
   const handleClearFilters = () => {
+    window.sessionStorage.removeItem(TARGETS_TABLE_STORAGE_KEY)
+    clearSearchDebounce()
     setFilters({
       q: "",
       technology: [],
@@ -278,6 +370,7 @@ export function TargetsClient({
       from: "",
       to: "",
     })
+    setDebouncedSearch("")
   }
 
   return (

--- a/drizzle/migrations/0014_natural_wendell_vaughn.sql
+++ b/drizzle/migrations/0014_natural_wendell_vaughn.sql
@@ -1,0 +1,16 @@
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";--> statement-breakpoint
+CREATE INDEX "idx_scan_result_detections_name_trgm" ON "scan_result_detections" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_result_detections_slug_trgm" ON "scan_result_detections" USING gin ("slug" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_result_detections_vendor_trgm" ON "scan_result_detections" USING gin ("vendor" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_result_detections_product_trgm" ON "scan_result_detections" USING gin ("product" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_result_detections_cpe_trgm" ON "scan_result_detections" USING gin ("cpe" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_search_document_trgm" ON "scan_results" USING gin ("search_document" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_input_trgm" ON "scan_results" USING gin ("input" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_url_trgm" ON "scan_results" USING gin ("url" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_final_url_trgm" ON "scan_results" USING gin ("final_url" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_host_trgm" ON "scan_results" USING gin ("host" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_title_trgm" ON "scan_results" USING gin ("title" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_server_trgm" ON "scan_results" USING gin ("web_server" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scan_results_cdn_name_trgm" ON "scan_results" USING gin ("cdn_name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scans_input_target_trgm" ON "scans" USING gin ("input_target" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_scans_normalized_target_trgm" ON "scans" USING gin ("normalized_target" gin_trgm_ops);

--- a/drizzle/migrations/meta/0014_snapshot.json
+++ b/drizzle/migrations/meta/0014_snapshot.json
@@ -1,0 +1,3943 @@
+{
+  "id": "fb8182bb-40a6-4f0e-8cb1-b6d6c6103203",
+  "prevId": "edd7383d-efc7-435d-8647-15078099df7f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_keys_key_hash": {
+          "name": "idx_api_keys_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_created_by_user_id_users_id_fk": {
+          "name": "api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_accounts_provider_account": {
+          "name": "idx_auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_accounts_user_id": {
+          "name": "idx_auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_sessions_token": {
+          "name": "idx_auth_sessions_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_sessions_user_id": {
+          "name": "idx_auth_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_verifications_identifier": {
+          "name": "idx_auth_verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canonical_targets": {
+      "name": "canonical_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "canonical_targets_normalized_target_unique": {
+          "name": "canonical_targets_normalized_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_target"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_enrichments": {
+      "name": "ip_enrichments",
+      "schema": "",
+      "columns": {
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_source": {
+          "name": "provider_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rdap_json": {
+          "name": "rdap_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bgp_json": {
+          "name": "bgp_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ptr_json": {
+          "name": "ptr_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reverse_ip_json": {
+          "name": "reverse_ip_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ip_enrichments_provider_name": {
+          "name": "idx_ip_enrichments_provider_name",
+          "columns": [
+            {
+              "expression": "provider_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_enrichments_refreshed_at": {
+          "name": "idx_ip_enrichments_refreshed_at",
+          "columns": [
+            {
+              "expression": "refreshed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_attempts": {
+      "name": "scan_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_scan_attempts_scan_id_status": {
+          "name": "idx_scan_attempts_scan_id_status",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_attempts_scan_id_scans_id_fk": {
+          "name": "scan_attempts_scan_id_scans_id_fk",
+          "tableFrom": "scan_attempts",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_attempts_scan_id_attempt_number_unique": {
+          "name": "scan_attempts_scan_id_attempt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_id",
+            "attempt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_comparisons": {
+      "name": "scan_comparisons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "baseline_scan_id": {
+          "name": "baseline_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_scan_id": {
+          "name": "comparison_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff_json": {
+          "name": "diff_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_comparisons_baseline_scan_id_scans_id_fk": {
+          "name": "scan_comparisons_baseline_scan_id_scans_id_fk",
+          "tableFrom": "scan_comparisons",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "baseline_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comparisons_comparison_scan_id_scans_id_fk": {
+          "name": "scan_comparisons_comparison_scan_id_scans_id_fk",
+          "tableFrom": "scan_comparisons",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "comparison_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_comparisons_baseline_scan_id_comparison_scan_id_unique": {
+          "name": "scan_comparisons_baseline_scan_id_comparison_scan_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "baseline_scan_id",
+            "comparison_scan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_events": {
+      "name": "scan_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "scan_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_events_scan_id_id": {
+          "name": "idx_scan_events_scan_id_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_events_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_phase_runs": {
+      "name": "scan_phase_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "scan_phase_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_phase_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_key": {
+          "name": "job_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_phase_runs_attempt_id_phase": {
+          "name": "idx_scan_phase_runs_attempt_id_phase",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_phase_runs_scan_id": {
+          "name": "idx_scan_phase_runs_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_phase_runs_status": {
+          "name": "idx_scan_phase_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_phase_runs_phase_status": {
+          "name": "idx_scan_phase_runs_phase_status",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_phase_runs_scan_id_scans_id_fk": {
+          "name": "scan_phase_runs_scan_id_scans_id_fk",
+          "tableFrom": "scan_phase_runs",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_phase_runs_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_phase_runs_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_phase_runs",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_phase_runs_result_id_scan_results_id_fk": {
+          "name": "scan_phase_runs_result_id_scan_results_id_fk",
+          "tableFrom": "scan_phase_runs",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_detections": {
+      "name": "scan_result_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "scan_result_detection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "technology_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product": {
+          "name": "product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpe": {
+          "name": "cpe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_detections_result_id": {
+          "name": "idx_scan_result_detections_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_detections_result_id_kind": {
+          "name": "idx_scan_result_detections_result_id_kind",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_detections_kind_name": {
+          "name": "idx_scan_result_detections_kind_name",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_detections_name_trgm": {
+          "name": "idx_scan_result_detections_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_result_detections_slug_trgm": {
+          "name": "idx_scan_result_detections_slug_trgm",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_result_detections_vendor_trgm": {
+          "name": "idx_scan_result_detections_vendor_trgm",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_result_detections_product_trgm": {
+          "name": "idx_scan_result_detections_product_trgm",
+          "columns": [
+            {
+              "expression": "product",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_result_detections_cpe_trgm": {
+          "name": "idx_scan_result_detections_cpe_trgm",
+          "columns": [
+            {
+              "expression": "cpe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_detections_result_id_scan_results_id_fk": {
+          "name": "scan_result_detections_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_detections",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_nuclei_matches": {
+      "name": "scan_result_nuclei_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_path": {
+          "name": "template_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matcher_name": {
+          "name": "matcher_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_type": {
+          "name": "protocol_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_at": {
+          "name": "matched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_results_json": {
+          "name": "extracted_results_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "technology_name": {
+          "name": "technology_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technology_version": {
+          "name": "technology_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_kind": {
+          "name": "finding_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_nuclei_matches_result_id": {
+          "name": "idx_scan_result_nuclei_matches_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_nuclei_matches_run_id": {
+          "name": "idx_scan_result_nuclei_matches_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_result_nuclei_matches_template_id": {
+          "name": "idx_scan_result_nuclei_matches_template_id",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_nuclei_matches_run_id_scan_result_nuclei_runs_id_fk": {
+          "name": "scan_result_nuclei_matches_run_id_scan_result_nuclei_runs_id_fk",
+          "tableFrom": "scan_result_nuclei_matches",
+          "tableTo": "scan_result_nuclei_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_result_nuclei_matches_result_id_scan_results_id_fk": {
+          "name": "scan_result_nuclei_matches_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_nuclei_matches",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_result_nuclei_runs": {
+      "name": "scan_result_nuclei_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_result_nuclei_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_domain_target": {
+          "name": "original_domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_domain_target": {
+          "name": "final_domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_target": {
+          "name": "domain_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "template_ids_json": {
+          "name": "template_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "templates_version": {
+          "name": "templates_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_result_nuclei_runs_result_id": {
+          "name": "idx_scan_result_nuclei_runs_result_id",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_result_nuclei_runs_result_id_scan_results_id_fk": {
+          "name": "scan_result_nuclei_runs_result_id_scan_results_id_fk",
+          "tableFrom": "scan_result_nuclei_runs",
+          "tableTo": "scan_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_results": {
+      "name": "scan_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_url": {
+          "name": "final_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_ip": {
+          "name": "host_ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_server": {
+          "name": "web_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "words": {
+          "name": "words",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines": {
+          "name": "lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn": {
+          "name": "cdn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_name": {
+          "name": "cdn_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cdn_type": {
+          "name": "cdn_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_mmh3": {
+          "name": "favicon_mmh3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_md5": {
+          "name": "favicon_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_path": {
+          "name": "favicon_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sni": {
+          "name": "sni",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jarm_hash": {
+          "name": "jarm_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_preview": {
+          "name": "body_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers_json": {
+          "name": "response_headers_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_a_records": {
+          "name": "dns_a_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_aaaa_records": {
+          "name": "dns_aaaa_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_cname_records": {
+          "name": "dns_cname_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_resolvers": {
+          "name": "dns_resolvers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asn_json": {
+          "name": "asn_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls_json": {
+          "name": "tls_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csp_json": {
+          "name": "csp_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashes_json": {
+          "name": "hashes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_domains": {
+          "name": "body_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_fqdns": {
+          "name": "body_fqdns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_chain_status_codes": {
+          "name": "redirect_chain_status_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_chain_json": {
+          "name": "redirect_chain_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http2": {
+          "name": "http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websocket": {
+          "name": "websocket",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vhost": {
+          "name": "vhost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_response_path": {
+          "name": "stored_response_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_object_key": {
+          "name": "screenshot_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_content_type": {
+          "name": "screenshot_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_byte_size": {
+          "name": "screenshot_byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_captured_at": {
+          "name": "screenshot_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed": {
+          "name": "failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_document": {
+          "name": "search_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scan_results_scan_id": {
+          "name": "idx_scan_results_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_status_code": {
+          "name": "idx_scan_results_status_code",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_final_url": {
+          "name": "idx_scan_results_final_url",
+          "columns": [
+            {
+              "expression": "final_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_location": {
+          "name": "idx_scan_results_location",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_host_ip": {
+          "name": "idx_scan_results_host_ip",
+          "columns": [
+            {
+              "expression": "host_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_server": {
+          "name": "idx_scan_results_server",
+          "columns": [
+            {
+              "expression": "web_server",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_cdn_name": {
+          "name": "idx_scan_results_cdn_name",
+          "columns": [
+            {
+              "expression": "cdn_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_search_document_trgm": {
+          "name": "idx_scan_results_search_document_trgm",
+          "columns": [
+            {
+              "expression": "search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_input_trgm": {
+          "name": "idx_scan_results_input_trgm",
+          "columns": [
+            {
+              "expression": "input",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_url_trgm": {
+          "name": "idx_scan_results_url_trgm",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_final_url_trgm": {
+          "name": "idx_scan_results_final_url_trgm",
+          "columns": [
+            {
+              "expression": "final_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_host_trgm": {
+          "name": "idx_scan_results_host_trgm",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_title_trgm": {
+          "name": "idx_scan_results_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_server_trgm": {
+          "name": "idx_scan_results_server_trgm",
+          "columns": [
+            {
+              "expression": "web_server",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_cdn_name_trgm": {
+          "name": "idx_scan_results_cdn_name_trgm",
+          "columns": [
+            {
+              "expression": "cdn_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scan_results_jarm_hash": {
+          "name": "idx_scan_results_jarm_hash",
+          "columns": [
+            {
+              "expression": "jarm_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_results_favicon_mmh3": {
+          "name": "idx_scan_results_favicon_mmh3",
+          "columns": [
+            {
+              "expression": "favicon_mmh3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_results_scan_id_scans_id_fk": {
+          "name": "scan_results_scan_id_scans_id_fk",
+          "tableFrom": "scan_results",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_results_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_results_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_results",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_run_scans": {
+      "name": "scan_schedule_run_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_run_id": {
+          "name": "schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedule_run_scans_scan_id": {
+          "name": "idx_scan_schedule_run_scans_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedule_run_scans_schedule_run_id_sort_order": {
+          "name": "idx_scan_schedule_run_scans_schedule_run_id_sort_order",
+          "columns": [
+            {
+              "expression": "schedule_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedule_run_scans_schedule_run_id_scan_schedule_runs_id_fk": {
+          "name": "scan_schedule_run_scans_schedule_run_id_scan_schedule_runs_id_fk",
+          "tableFrom": "scan_schedule_run_scans",
+          "tableTo": "scan_schedule_runs",
+          "columnsFrom": [
+            "schedule_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_schedule_run_scans_scan_id_scans_id_fk": {
+          "name": "scan_schedule_run_scans_scan_id_scans_id_fk",
+          "tableFrom": "scan_schedule_run_scans",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_run_scans_schedule_run_id_scan_id_unique": {
+          "name": "scan_schedule_run_scans_schedule_run_id_scan_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_run_id",
+            "scan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_runs": {
+      "name": "scan_schedule_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_schedule_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_at": {
+          "name": "scheduled_for_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_scan_count": {
+          "name": "queued_scan_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedule_runs_schedule_id_created_at": {
+          "name": "idx_scan_schedule_runs_schedule_id_created_at",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedule_runs_schedule_id_scheduled_for_at": {
+          "name": "idx_scan_schedule_runs_schedule_id_scheduled_for_at",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedule_runs_schedule_id_scan_schedules_id_fk": {
+          "name": "scan_schedule_runs_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scan_schedule_runs",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_runs_schedule_id_scheduled_for_at_unique": {
+          "name": "scan_schedule_runs_schedule_id_scheduled_for_at_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "scheduled_for_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedule_targets": {
+      "name": "scan_schedule_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_target_id": {
+          "name": "canonical_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_target": {
+          "name": "input_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_schedule_targets_schedule_id_scan_schedules_id_fk": {
+          "name": "scan_schedule_targets_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scan_schedule_targets",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_schedule_targets_canonical_target_id_canonical_targets_id_fk": {
+          "name": "scan_schedule_targets_canonical_target_id_canonical_targets_id_fk",
+          "tableFrom": "scan_schedule_targets",
+          "tableTo": "canonical_targets",
+          "columnsFrom": [
+            "canonical_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scan_schedule_targets_schedule_id_normalized_target_unique": {
+          "name": "scan_schedule_targets_schedule_id_normalized_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "normalized_target"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_schedules": {
+      "name": "scan_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "scan_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minute": {
+          "name": "minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_schedules_created_by_user_id": {
+          "name": "idx_scan_schedules_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_schedules_enabled_next_run_at": {
+          "name": "idx_scan_schedules_enabled_next_run_at",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_schedules_created_by_user_id_users_id_fk": {
+          "name": "scan_schedules_created_by_user_id_users_id_fk",
+          "tableFrom": "scan_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_subdomain_discovery_runs": {
+      "name": "scan_subdomain_discovery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_subdomain_discovery_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain": {
+          "name": "target_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_subdomain_discovery_runs_attempt_id": {
+          "name": "idx_scan_subdomain_discovery_runs_attempt_id",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_subdomain_discovery_runs_scan_id": {
+          "name": "idx_scan_subdomain_discovery_runs_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_subdomain_discovery_runs_scan_id_scans_id_fk": {
+          "name": "scan_subdomain_discovery_runs_scan_id_scans_id_fk",
+          "tableFrom": "scan_subdomain_discovery_runs",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_subdomain_discovery_runs_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_subdomain_discovery_runs_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_subdomain_discovery_runs",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_subdomains": {
+      "name": "scan_subdomains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_domain": {
+          "name": "root_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_key": {
+          "name": "ip_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "wildcard_certificate": {
+          "name": "wildcard_certificate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scan_subdomains_run_host_ip_source_key": {
+          "name": "idx_scan_subdomains_run_host_ip_source_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_subdomains_scan_id": {
+          "name": "idx_scan_subdomains_scan_id",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_subdomains_run_id": {
+          "name": "idx_scan_subdomains_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_subdomains_root_domain": {
+          "name": "idx_scan_subdomains_root_domain",
+          "columns": [
+            {
+              "expression": "root_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scan_subdomains_host": {
+          "name": "idx_scan_subdomains_host",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_subdomains_scan_id_scans_id_fk": {
+          "name": "scan_subdomains_scan_id_scans_id_fk",
+          "tableFrom": "scan_subdomains",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_subdomains_attempt_id_scan_attempts_id_fk": {
+          "name": "scan_subdomains_attempt_id_scan_attempts_id_fk",
+          "tableFrom": "scan_subdomains",
+          "tableTo": "scan_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_subdomains_run_id_scan_subdomain_discovery_runs_id_fk": {
+          "name": "scan_subdomains_run_id_scan_subdomain_discovery_runs_id_fk",
+          "tableFrom": "scan_subdomains",
+          "tableTo": "scan_subdomain_discovery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scans": {
+      "name": "scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_api_key_id": {
+          "name": "created_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "scan_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_schema_version": {
+          "name": "request_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "canonical_target_id": {
+          "name": "canonical_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_target": {
+          "name": "input_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scheduled_for_at": {
+          "name": "scheduled_for_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scans_submitted_at": {
+          "name": "idx_scans_submitted_at",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_status": {
+          "name": "idx_scans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_schedule_id": {
+          "name": "idx_scans_schedule_id",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_normalized_target": {
+          "name": "idx_scans_normalized_target",
+          "columns": [
+            {
+              "expression": "normalized_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_input_target_trgm": {
+          "name": "idx_scans_input_target_trgm",
+          "columns": [
+            {
+              "expression": "input_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scans_normalized_target_trgm": {
+          "name": "idx_scans_normalized_target_trgm",
+          "columns": [
+            {
+              "expression": "normalized_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_scans_request_fingerprint": {
+          "name": "idx_scans_request_fingerprint",
+          "columns": [
+            {
+              "expression": "request_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_idempotency_key": {
+          "name": "idx_scans_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"scans\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scans_schedule_slot": {
+          "name": "idx_scans_schedule_slot",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scans_created_by_user_id_users_id_fk": {
+          "name": "scans_created_by_user_id_users_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_created_by_api_key_id_api_keys_id_fk": {
+          "name": "scans_created_by_api_key_id_api_keys_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "created_by_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_schedule_id_scan_schedules_id_fk": {
+          "name": "scans_schedule_id_scan_schedules_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "scan_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_canonical_target_id_canonical_targets_id_fk": {
+          "name": "scans_canonical_target_id_canonical_targets_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "canonical_targets",
+          "columnsFrom": [
+            "canonical_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_product_state": {
+      "name": "user_product_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_release_version": {
+          "name": "last_seen_release_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "getting_started_dismissed_at": {
+          "name": "getting_started_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_product_state_user_id_users_id_fk": {
+          "name": "user_product_state_user_id_users_id_fk",
+          "tableFrom": "user_product_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_access_enabled": {
+          "name": "api_key_access_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_change_required_at": {
+          "name": "password_change_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attempt_status": {
+      "name": "attempt_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.scan_result_detection_kind": {
+      "name": "scan_result_detection_kind",
+      "schema": "public",
+      "values": [
+        "technology",
+        "wordpress_plugin",
+        "wordpress_theme",
+        "cpe"
+      ]
+    },
+    "public.scan_result_nuclei_run_status": {
+      "name": "scan_result_nuclei_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.scan_event_type": {
+      "name": "scan_event_type",
+      "schema": "public",
+      "values": [
+        "scan.status",
+        "scan.phase",
+        "scan.progress",
+        "scan.result",
+        "scan.complete",
+        "scan.failed",
+        "scan.cancelled"
+      ]
+    },
+    "public.scan_phase_kind": {
+      "name": "scan_phase_kind",
+      "schema": "public",
+      "values": [
+        "http_probe",
+        "headless",
+        "subfinder",
+        "nuclei_dns",
+        "nuclei_http",
+        "ip_intel",
+        "finalize"
+      ]
+    },
+    "public.scan_phase_status": {
+      "name": "scan_phase_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "skipped",
+        "cancelled"
+      ]
+    },
+    "public.scan_schedule_frequency": {
+      "name": "scan_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.scan_schedule_run_status": {
+      "name": "scan_schedule_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.scan_source": {
+      "name": "scan_source",
+      "schema": "public",
+      "values": [
+        "ui",
+        "cli",
+        "api",
+        "system"
+      ]
+    },
+    "public.scan_status": {
+      "name": "scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "running",
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.scan_subdomain_discovery_run_status": {
+      "name": "scan_subdomain_discovery_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.target_type": {
+      "name": "target_type",
+      "schema": "public",
+      "values": [
+        "url",
+        "host",
+        "domain"
+      ]
+    },
+    "public.technology_source": {
+      "name": "technology_source",
+      "schema": "public",
+      "values": [
+        "wappalyzer",
+        "wordpress",
+        "cpe",
+        "derived",
+        "nuclei"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780246173361,
       "tag": "0013_wooden_robin_chapel",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780349341053,
+      "tag": "0014_natural_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -273,6 +273,8 @@ export const scans = pgTable(
     index("idx_scans_status").on(table.status),
     index("idx_scans_schedule_id").on(table.scheduleId),
     index("idx_scans_normalized_target").on(table.normalizedTarget),
+    index("idx_scans_input_target_trgm").using("gin", table.inputTarget.op("gin_trgm_ops")),
+    index("idx_scans_normalized_target_trgm").using("gin", table.normalizedTarget.op("gin_trgm_ops")),
     index("idx_scans_request_fingerprint").on(table.requestFingerprint, table.submittedAt),
     uniqueIndex("idx_scans_idempotency_key")
       .on(table.idempotencyKey)
@@ -395,6 +397,14 @@ export const scanResults = pgTable(
     index("idx_scan_results_host_ip").on(table.hostIp),
     index("idx_scan_results_server").on(table.webServer),
     index("idx_scan_results_cdn_name").on(table.cdnName),
+    index("idx_scan_results_search_document_trgm").using("gin", table.searchDocument.op("gin_trgm_ops")),
+    index("idx_scan_results_input_trgm").using("gin", table.input.op("gin_trgm_ops")),
+    index("idx_scan_results_url_trgm").using("gin", table.url.op("gin_trgm_ops")),
+    index("idx_scan_results_final_url_trgm").using("gin", table.finalUrl.op("gin_trgm_ops")),
+    index("idx_scan_results_host_trgm").using("gin", table.host.op("gin_trgm_ops")),
+    index("idx_scan_results_title_trgm").using("gin", table.title.op("gin_trgm_ops")),
+    index("idx_scan_results_server_trgm").using("gin", table.webServer.op("gin_trgm_ops")),
+    index("idx_scan_results_cdn_name_trgm").using("gin", table.cdnName.op("gin_trgm_ops")),
     index("idx_scan_results_jarm_hash").on(table.jarmHash),
     index("idx_scan_results_favicon_mmh3").on(table.faviconMmh3),
   ],
@@ -442,6 +452,11 @@ export const scanResultDetections = pgTable(
     index("idx_scan_result_detections_result_id").on(table.resultId),
     index("idx_scan_result_detections_result_id_kind").on(table.resultId, table.kind),
     index("idx_scan_result_detections_kind_name").on(table.kind, table.name),
+    index("idx_scan_result_detections_name_trgm").using("gin", table.name.op("gin_trgm_ops")),
+    index("idx_scan_result_detections_slug_trgm").using("gin", table.slug.op("gin_trgm_ops")),
+    index("idx_scan_result_detections_vendor_trgm").using("gin", table.vendor.op("gin_trgm_ops")),
+    index("idx_scan_result_detections_product_trgm").using("gin", table.product.op("gin_trgm_ops")),
+    index("idx_scan_result_detections_cpe_trgm").using("gin", table.cpe.op("gin_trgm_ops")),
   ],
 );
 

--- a/lib/queries/runs.ts
+++ b/lib/queries/runs.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, exists, ilike, inArray, or, sql } from "drizzle-orm";
 
 import type { RunsPhaseKind, RunsRow, RunsSourceValue, RunsStatusValue } from "@/components/runs/types";
 import {
@@ -21,7 +21,7 @@ import {
 } from "@/lib/contracts/runs";
 import type { ScanListItem } from "@/lib/contracts/scans";
 import { db } from "@/lib/db/client";
-import { apiKeys, scanPhaseRuns, scans, users } from "@/lib/db/schema";
+import { apiKeys, scanPhaseRuns, scanResultDetections, scanResults, scans, users } from "@/lib/db/schema";
 import type { RunsRowEnrichment } from "@/lib/queries/runs.types";
 import { requireAppSession } from "@/lib/session/app-session";
 import type { ActorContext } from "@/lib/session/actor-context";
@@ -495,17 +495,6 @@ async function buildRunsRowsForScanRecords(actor: ActorContext, scanRows: readon
   );
 }
 
-async function getAllRunsRows(actor: ActorContext): Promise<RunsRow[]> {
-  const visibleScansFilter = getVisibleScansFilter(actor);
-  const scanRows = await db
-    .select()
-    .from(scans)
-    .where(visibleScansFilter)
-    .orderBy(desc(scans.submittedAt));
-
-  return buildRunsRowsForScanRecords(actor, scanRows);
-}
-
 async function listRunsWithoutSearch(actor: ActorContext, query: RunsListQuery): Promise<RunsListResponse> {
   const normalizedStatuses = getRawStatusesForRunsFilter(query.status);
   const cursorOffset = query.cursor ? Number.parseInt(query.cursor, 10) : 0;
@@ -537,6 +526,90 @@ async function listRunsWithoutSearch(actor: ActorContext, query: RunsListQuery):
   });
 }
 
+function getRunsCandidateSearchFilter(query: string) {
+  const pattern = `%${query}%`;
+
+  return or(
+    ilike(sql<string>`${scans.id}::text`, pattern),
+    ilike(scans.inputTarget, pattern),
+    ilike(scans.normalizedTarget, pattern),
+    exists(
+      db
+        .select({ id: users.id })
+        .from(users)
+        .where(
+          and(
+            eq(users.id, scans.createdByUserId),
+            or(ilike(users.displayName, pattern), ilike(users.email, pattern)),
+          ),
+        ),
+    ),
+    exists(
+      db
+        .select({ id: apiKeys.id })
+        .from(apiKeys)
+        .where(and(eq(apiKeys.id, scans.createdByApiKeyId), ilike(apiKeys.name, pattern))),
+    ),
+    exists(
+      db
+        .select({ id: scanResults.id })
+        .from(scanResults)
+        .where(
+          and(
+            eq(scanResults.scanId, scans.id),
+            or(
+              ilike(scanResults.searchDocument, pattern),
+              ilike(scanResults.input, pattern),
+              ilike(scanResults.url, pattern),
+              ilike(scanResults.finalUrl, pattern),
+              ilike(scanResults.host, pattern),
+              ilike(scanResults.title, pattern),
+              ilike(scanResults.webServer, pattern),
+              ilike(scanResults.cdnName, pattern),
+              exists(
+                db
+                  .select({ id: scanResultDetections.id })
+                  .from(scanResultDetections)
+                  .where(
+                    and(
+                      eq(scanResultDetections.resultId, scanResults.id),
+                      or(
+                        ilike(scanResultDetections.name, pattern),
+                        ilike(scanResultDetections.slug, pattern),
+                        ilike(scanResultDetections.vendor, pattern),
+                        ilike(scanResultDetections.product, pattern),
+                        ilike(scanResultDetections.cpe, pattern),
+                      ),
+                    ),
+                  ),
+              ),
+            ),
+          ),
+        ),
+    ),
+  );
+}
+
+async function getCandidateRunsRows(actor: ActorContext, query: RunsListQuery): Promise<RunsRow[]> {
+  const visibleScansFilter = getVisibleScansFilter(actor);
+  const normalizedStatuses = getRawStatusesForRunsFilter(query.status);
+  const orderByDirection = query.sort === "oldest" ? asc : desc;
+  const scanRows = await db
+    .select()
+    .from(scans)
+    .where(
+      and(
+        visibleScansFilter,
+        normalizedStatuses ? inArray(scans.status, normalizedStatuses) : undefined,
+        query.source ? eq(scans.source, query.source) : undefined,
+        query.q ? getRunsCandidateSearchFilter(query.q) : undefined,
+      ),
+    )
+    .orderBy(orderByDirection(scans.submittedAt), orderByDirection(scans.id));
+
+  return buildRunsRowsForScanRecords(actor, scanRows);
+}
+
 export async function listRuns(actor: ActorContext, searchParams?: RunsParamsInput): Promise<RunsListResponse> {
   const query = parseRunsQuery(searchParams);
 
@@ -544,7 +617,7 @@ export async function listRuns(actor: ActorContext, searchParams?: RunsParamsInp
     return listRunsWithoutSearch(actor, query);
   }
 
-  const rows = await getAllRunsRows(actor);
+  const rows = await getCandidateRunsRows(actor, query);
   return buildRunsListResponse(rows, searchParams);
 }
 

--- a/lib/server/scans/read-service.test.ts
+++ b/lib/server/scans/read-service.test.ts
@@ -138,6 +138,7 @@ function createCompletedSnapshot(overrides: Partial<CompletedResultSnapshot> = {
     scanId: "scan_01",
     canonicalTargetId: "canonical_01",
     normalizedTarget: "example.com",
+    searchDocument: "",
     title: "Example",
     technologies: ["Nginx"],
     wordpressPlugins: [],

--- a/lib/server/scans/read-service.ts
+++ b/lib/server/scans/read-service.ts
@@ -154,6 +154,7 @@ export interface CompletedResultSnapshot {
   scanId: string;
   canonicalTargetId: string;
   normalizedTarget: string;
+  searchDocument: string;
   title: string;
   technologies: string[];
   wordpressPlugins: string[];
@@ -424,6 +425,7 @@ export function mapCompletedResultSnapshot(
     scanId: authoritativeResult.scanId,
     canonicalTargetId: scan.canonicalTargetId,
     normalizedTarget: scan.normalizedTarget,
+    searchDocument: authoritativeResult.searchDocument ?? "",
     title: resultItem.title,
     technologies: resultItem.technologies,
     wordpressPlugins: resultItem.wordpress.plugins,
@@ -813,14 +815,14 @@ function buildNucleiBlock(decorations: ResultDecorations | undefined) {
   };
 }
 
-function getVisibleTechnologies(result: ResultRecord, decorations: ResultDecorations | undefined) {
+function getVisibleTechnologies(decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologies({
     persistedTechnologies: (decorations?.technologies ?? []).map((technology) => technology.name),
     cpeEntries: decorations?.cpe ?? [],
   });
 }
 
-function getStructuredTechnologyDetections(result: ResultRecord, decorations: ResultDecorations | undefined) {
+function getStructuredTechnologyDetections(decorations: ResultDecorations | undefined) {
   return buildEnrichedTechnologyDetections({
     persistedTechnologies: decorations?.technologies ?? [],
     cpeEntries: decorations?.cpe ?? [],
@@ -1166,8 +1168,8 @@ export function mapResultItem(
   ipIntelligence: IpEnrichmentRecord | null = null,
   internalReverseIpMatches: readonly InternalReverseIpMatch[] = [],
 ) {
-  const technologies = getVisibleTechnologies(result, decorations);
-  const technologyDetections = getStructuredTechnologyDetections(result, decorations);
+  const technologies = getVisibleTechnologies(decorations);
+  const technologyDetections = getStructuredTechnologyDetections(decorations);
   const screenshotPath = result.screenshotObjectKey
     ? `/api/v1/scans/${result.scanId}/results/${result.id}/screenshot`
     : null;
@@ -1284,14 +1286,14 @@ function matchesTargetFilter(scan: Pick<ScanRecord, "inputTarget" | "normalizedT
     .includes(normalizedFilter);
 }
 
-function matchesTechnologyFilter(result: ResultRecord, decorations: ResultDecorations | undefined, filter: string | null | undefined) {
+function matchesTechnologyFilter(decorations: ResultDecorations | undefined, filter: string | null | undefined) {
   if (!filter) {
     return true;
   }
 
   const normalizedFilter = normalizeSearchToken(filter);
 
-  return getVisibleTechnologies(result, decorations).some((technology) => normalizeSearchToken(technology).includes(normalizedFilter));
+  return getVisibleTechnologies(decorations).some((technology) => normalizeSearchToken(technology).includes(normalizedFilter));
 }
 
 export async function listScans(actor: ActorContext, filters: ScanListFilters = {}) {
@@ -1509,7 +1511,7 @@ export async function getScanResults(actor: ActorContext, scanId: string, filter
       return false;
     }
 
-    if (!matchesTechnologyFilter(result, decorations, filters.technology)) {
+    if (!matchesTechnologyFilter(decorations, filters.technology)) {
       return false;
     }
 

--- a/lib/server/targets/service.test.ts
+++ b/lib/server/targets/service.test.ts
@@ -2,7 +2,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ActorContext } from "@/lib/session/actor-context";
 import { listCompletedResultSnapshots, type CompletedResultSnapshot } from "@/lib/server/scans/read-service";
-import { getTechnologyComparisonResults } from "@/lib/server/targets/service";
+import { getTargetResults, getTechnologyComparisonResults } from "@/lib/server/targets/service";
+
+const selectDistinctOnMock = vi.hoisted(() => vi.fn());
+const selectMock = vi.hoisted(() => vi.fn());
+
+function createQueryChain<T>(result: T) {
+  const promise = Promise.resolve(result);
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+    finally: promise.finally.bind(promise),
+    [Symbol.toStringTag]: "Promise",
+  };
+
+  return chain;
+}
+
+vi.mock("@/lib/db/client", () => ({
+  db: {
+    select: selectMock,
+    selectDistinctOn: selectDistinctOnMock,
+  },
+}));
 
 vi.mock("@/lib/server/scans/read-service", () => ({
   listCompletedResultSnapshots: vi.fn(),
@@ -29,6 +54,7 @@ function snapshot(overrides: Partial<CompletedResultSnapshot>): CompletedResultS
     scanId: "scn_test",
     canonicalTargetId: "ctg_test",
     normalizedTarget: "example.com",
+    searchDocument: "",
     title: "Example",
     technologies: [],
     wordpressPlugins: [],
@@ -47,6 +73,8 @@ function snapshot(overrides: Partial<CompletedResultSnapshot>): CompletedResultS
 describe("technology comparison results", () => {
   beforeEach(() => {
     listCompletedResultSnapshotsMock.mockReset();
+    selectDistinctOnMock.mockReset();
+    selectMock.mockReset();
   });
 
   it("requires distinct exact technology matches for multi-technology comparisons", async () => {
@@ -73,5 +101,125 @@ describe("technology comparison results", () => {
       "React",
       "React Native",
     ]);
+  });
+});
+
+describe("target results", () => {
+  beforeEach(() => {
+    listCompletedResultSnapshotsMock.mockReset();
+    selectDistinctOnMock.mockReset();
+    selectMock.mockReset();
+  });
+
+  it("uses completed snapshots for latest-target filtering", async () => {
+    selectMock.mockReturnValue(createQueryChain([]));
+    selectDistinctOnMock
+      .mockReturnValueOnce(createQueryChain([{ canonicalTargetId: "ctg_wordpress" }]))
+      .mockReturnValueOnce(createQueryChain([{ id: "scn_wordpress" }]));
+    listCompletedResultSnapshotsMock.mockResolvedValue([
+      snapshot({
+        canonicalTargetId: "ctg_wordpress",
+        scanId: "scn_wordpress",
+        normalizedTarget: "wordpress.org",
+        title: "WordPress",
+        technologies: ["WordPress", "PHP"],
+        wordpressPlugins: ["jetpack"],
+        statusCode: 200,
+        server: "nginx",
+        cdn: "cloudflare",
+        completedAt: "2026-05-27T12:00:00.000Z",
+        faviconUrl: "/favicon.ico",
+        screenshotUrl: "/api/v1/scans/scn_wordpress/results/res_wordpress/screenshot",
+      }),
+    ]);
+
+    const response = await getTargetResults(actor, new URLSearchParams("plugin=jetpack&limit=1"));
+
+    expect(selectDistinctOnMock).toHaveBeenCalledTimes(2);
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledTimes(1);
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledWith(actor, ["scn_wordpress"]);
+    expect(response).toEqual({
+      items: [
+        {
+          canonicalTargetId: "ctg_wordpress",
+          normalizedTarget: "wordpress.org",
+          latestScanId: "scn_wordpress",
+          title: "WordPress",
+          technologies: ["WordPress", "PHP"],
+          lastScannedAt: "2026-05-27T12:00:00.000Z",
+          faviconUrl: "/favicon.ico",
+          screenshotUrl: "/api/v1/scans/scn_wordpress/results/res_wordpress/screenshot",
+        },
+      ],
+      nextCursor: null,
+    });
+  });
+
+  it("falls back to helper-safe hydration for free-text searches", async () => {
+    listCompletedResultSnapshotsMock.mockResolvedValue([
+      snapshot({
+        canonicalTargetId: "ctg_wordpress",
+        scanId: "scn_wordpress",
+        normalizedTarget: "wordpress.org",
+        title: "WordPress",
+        technologies: ["WordPress", "PHP"],
+      }),
+      snapshot({
+        canonicalTargetId: "ctg_other",
+        scanId: "scn_other",
+        normalizedTarget: "example.org",
+        title: "Example",
+        technologies: ["React"],
+      }),
+    ]);
+
+    const response = await getTargetResults(actor, new URLSearchParams("q=wordpress&limit=1"));
+
+    expect(selectDistinctOnMock).not.toHaveBeenCalled();
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledTimes(1);
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledWith(actor);
+    expect(response.items.map((item) => item.canonicalTargetId)).toEqual(["ctg_wordpress"]);
+  });
+
+  it("matches target free-text against the stored result search document", async () => {
+    listCompletedResultSnapshotsMock.mockResolvedValue([
+      snapshot({
+        canonicalTargetId: "ctg_hash",
+        normalizedTarget: "fingerprint.example",
+        title: "Fingerprint Example",
+        searchDocument: "redirect https://final.example AS15169 jarm:fad2b2f favicon:mmh3:12345",
+      }),
+      snapshot({
+        canonicalTargetId: "ctg_other",
+        normalizedTarget: "example.org",
+        title: "Example",
+        searchDocument: "react nginx",
+      }),
+    ]);
+
+    const response = await getTargetResults(actor, new URLSearchParams("q=AS15169&limit=1"));
+
+    expect(selectDistinctOnMock).not.toHaveBeenCalled();
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledWith(actor);
+    expect(response.items.map((item) => item.canonicalTargetId)).toEqual(["ctg_hash"]);
+  });
+
+  it("falls back to helper-safe hydration for derived server and cdn filters", async () => {
+    listCompletedResultSnapshotsMock.mockResolvedValue([
+      snapshot({
+        canonicalTargetId: "ctg_vercel",
+        scanId: "scn_vercel",
+        normalizedTarget: "vercel.com",
+        title: "Vercel",
+        server: "Vercel",
+        cdn: "Vercel Edge",
+      }),
+    ]);
+
+    const response = await getTargetResults(actor, new URLSearchParams("server=vercel&cdn=edge&limit=1"));
+
+    expect(selectDistinctOnMock).not.toHaveBeenCalled();
+    expect(listCompletedResultSnapshotsMock).toHaveBeenCalledWith(actor);
+    expect(response.items.map((item) => item.canonicalTargetId)).toEqual(["ctg_vercel"]);
   });
 });

--- a/lib/server/targets/service.ts
+++ b/lib/server/targets/service.ts
@@ -1,5 +1,10 @@
+import { and, desc, eq, exists, gte, ilike, inArray, isNotNull, lte, or, sql } from "drizzle-orm";
+
 import { targetResultsResponseSchema, technologyComparisonOptionsResponseSchema, technologyComparisonResponseSchema } from "@/lib/contracts/targets";
+import { db } from "@/lib/db/client";
+import { scanResultDetections, scanResults, scans } from "@/lib/db/schema";
 import type { ActorContext } from "@/lib/session/actor-context";
+import { getVisibleScansFilter } from "@/lib/server/scans/access";
 import { listCompletedResultSnapshots, type CompletedResultSnapshot } from "@/lib/server/scans/read-service";
 import { buildStructuredTechnologyDetection } from "@/lib/server/scans/technology-metadata-catalog";
 import { parseTargetQuery, type TargetParamsInput, type TargetQuery } from "@/lib/targets/shared";
@@ -162,6 +167,7 @@ function matchesQuery(snapshot: CompletedResultSnapshot, query: TargetQuery): bo
   if (query.q) {
     const searchableText = [
       snapshot.normalizedTarget,
+      snapshot.searchDocument,
       snapshot.title,
       ...snapshot.technologies,
       snapshot.server ?? "",
@@ -213,9 +219,182 @@ function matchesQuery(snapshot: CompletedResultSnapshot, query: TargetQuery): bo
   return matchesDateRange(snapshot, query);
 }
 
+function hasTargetCandidateFilters(query: TargetQuery): boolean {
+  return Boolean(
+    query.q
+    || query.technology.length > 0
+    || query.cdn.length > 0
+    || query.server.length > 0
+    || query.plugin.length > 0
+    || query.theme.length > 0
+    || query.cpe.length > 0
+    || query.statusCode.length > 0
+    || query.from
+    || query.to,
+  );
+}
+
+function ilikeAny(column: Parameters<typeof ilike>[0], filters: readonly string[]) {
+  if (filters.length === 0) {
+    return undefined;
+  }
+
+  return or(...filters.map((filter) => ilike(column, `%${filter}%`)));
+}
+
+function detectionTextMatches(filters: readonly string[]) {
+  if (filters.length === 0) {
+    return undefined;
+  }
+
+  return or(
+    ilikeAny(scanResultDetections.name, filters),
+    ilikeAny(scanResultDetections.slug, filters),
+    ilikeAny(scanResultDetections.vendor, filters),
+    ilikeAny(scanResultDetections.product, filters),
+    ilikeAny(scanResultDetections.cpe, filters),
+  );
+}
+
+function hasUnsupportedDerivedTargetFilters(query: TargetQuery): boolean {
+  return Boolean(query.q || query.cdn.length > 0 || query.server.length > 0);
+}
+
+function hasResultMatching(condition: ReturnType<typeof and> | ReturnType<typeof or>) {
+  if (!condition) {
+    return undefined;
+  }
+
+  return exists(
+    db
+      .select({ id: scanResults.id })
+      .from(scanResults)
+      .where(and(eq(scanResults.scanId, scans.id), condition)),
+  );
+}
+
+function hasDetectionMatching(condition: ReturnType<typeof and> | ReturnType<typeof or>) {
+  if (!condition) {
+    return undefined;
+  }
+
+  return hasResultMatching(
+    exists(
+      db
+        .select({ id: scanResultDetections.id })
+        .from(scanResultDetections)
+        .where(and(eq(scanResultDetections.resultId, scanResults.id), condition)),
+    ),
+  );
+}
+
+function getTargetCandidateFilter(query: TargetQuery) {
+  const qPattern = query.q ? `%${query.q}%` : null;
+
+  return and(
+    query.from ? gte(scans.completedAt, new Date(query.from)) : undefined,
+    query.to ? lte(scans.completedAt, new Date(query.to)) : undefined,
+    qPattern
+      ? or(
+          ilike(scans.normalizedTarget, qPattern),
+          hasResultMatching(
+            or(
+              ilike(scanResults.searchDocument, qPattern),
+              ilike(scanResults.input, qPattern),
+              ilike(scanResults.url, qPattern),
+              ilike(scanResults.finalUrl, qPattern),
+              ilike(scanResults.host, qPattern),
+              ilike(scanResults.title, qPattern),
+              ilike(scanResults.webServer, qPattern),
+              ilike(scanResults.cdnName, qPattern),
+              sql`${scanResults.statusCode}::text ILIKE ${qPattern}`,
+              exists(
+                db
+                  .select({ id: scanResultDetections.id })
+                  .from(scanResultDetections)
+                  .where(
+                    and(
+                      eq(scanResultDetections.resultId, scanResults.id),
+                      or(
+                        ilike(scanResultDetections.name, qPattern),
+                        ilike(scanResultDetections.slug, qPattern),
+                        ilike(scanResultDetections.vendor, qPattern),
+                        ilike(scanResultDetections.product, qPattern),
+                        ilike(scanResultDetections.cpe, qPattern),
+                      ),
+                    ),
+                  ),
+              ),
+            ),
+          ),
+        )
+      : undefined,
+    query.technology.length > 0 ? hasDetectionMatching(detectionTextMatches(query.technology)) : undefined,
+    query.plugin.length > 0 ? hasDetectionMatching(detectionTextMatches(query.plugin)) : undefined,
+    query.theme.length > 0 ? hasDetectionMatching(detectionTextMatches(query.theme)) : undefined,
+    query.cpe.length > 0
+      ? hasDetectionMatching(or(ilikeAny(scanResultDetections.cpe, query.cpe), ilikeAny(scanResultDetections.name, query.cpe)))
+      : undefined,
+    query.cdn.length > 0 ? hasResultMatching(ilikeAny(scanResults.cdnName, query.cdn)) : undefined,
+    query.server.length > 0 ? hasResultMatching(ilikeAny(scanResults.webServer, query.server)) : undefined,
+    query.statusCode.length > 0 ? hasResultMatching(inArray(scanResults.statusCode, query.statusCode)) : undefined,
+  );
+}
+
+async function getCandidateTargetIds(actor: ActorContext, query: TargetQuery): Promise<string[]> {
+  const visibleScansFilter = getVisibleScansFilter(actor);
+  const rows = await db
+    .selectDistinctOn([scans.canonicalTargetId], { canonicalTargetId: scans.canonicalTargetId })
+    .from(scans)
+    .where(
+      and(
+        eq(scans.status, "completed"),
+        visibleScansFilter,
+        isNotNull(scans.canonicalTargetId),
+        getTargetCandidateFilter(query),
+      ),
+    )
+    .orderBy(scans.canonicalTargetId, desc(scans.completedAt), desc(scans.id));
+
+  return rows.flatMap((row) => row.canonicalTargetId ? [row.canonicalTargetId] : []);
+}
+
+async function getLatestCompletedTargetScanIds(actor: ActorContext, candidateTargetIds: readonly string[]): Promise<string[]> {
+  if (candidateTargetIds.length === 0) {
+    return [];
+  }
+
+  const visibleScansFilter = getVisibleScansFilter(actor);
+  const rows = await db
+    .selectDistinctOn([scans.canonicalTargetId], { id: scans.id })
+    .from(scans)
+    .where(
+      and(
+        eq(scans.status, "completed"),
+        visibleScansFilter,
+        isNotNull(scans.canonicalTargetId),
+        inArray(scans.canonicalTargetId, candidateTargetIds),
+      ),
+    )
+    .orderBy(scans.canonicalTargetId, desc(scans.completedAt), desc(scans.id));
+
+  return rows.map((row) => row.id);
+}
+
+async function listTargetResultSnapshots(actor: ActorContext, query: TargetQuery) {
+  if (!hasTargetCandidateFilters(query) || hasUnsupportedDerivedTargetFilters(query)) {
+    return listCompletedResultSnapshots(actor);
+  }
+
+  const candidateTargetIds = await getCandidateTargetIds(actor, query);
+  const latestScanIds = await getLatestCompletedTargetScanIds(actor, candidateTargetIds);
+
+  return listCompletedResultSnapshots(actor, latestScanIds);
+}
+
 export async function getTargetResults(actor: ActorContext, searchParams?: TargetParamsInput) {
   const query = parseTargetQuery(searchParams);
-  const snapshots = await listCompletedResultSnapshots(actor);
+  const snapshots = await listTargetResultSnapshots(actor, query);
   const latestSnapshots = getLatestSnapshots(snapshots);
   const latestScanIdByTarget = new Map(latestSnapshots.map((snapshot) => [snapshot.canonicalTargetId, snapshot.scanId]));
   const filtered = latestSnapshots.filter((snapshot) => matchesQuery(snapshot, query));


### PR DESCRIPTION
## Summary
- persist Runs and Targets table filters in sessionStorage, with clear-filter cleanup and stale debounce cancellation
- add DB candidate narrowing for Runs and Targets while preserving helper/domain filtering semantics
- add pg_trgm plus GIN trigram indexes for searched scan/result/detection text fields

## Verification
- LSP diagnostics clean on changed TypeScript files
- pnpm vitest run lib/server/targets/service.test.ts lib/server/scans/read-service.test.ts lib/queries/targets.test.ts lib/queries/runs.test.ts components/targets/targets-client.test.tsx components/runs/runs-client.test.tsx scripts/startup-migrate.test.ts
- pnpm typecheck
- pnpm lint
- GIT_MASTER=1 git diff --check
- pnpm build
- Browser QA: /runs search+clear, /targets search+clear, /targets?plugin=jetpack URL precedence