### PR TITLE
chore: update scanner pins

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,2 +1,2 @@
 // Single source of truth - keep this in sync with package.json.
-export const APP_VERSION = "0.1.15"
+export const APP_VERSION = "0.1.16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackray",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.8.0
+ARG NUCLEI_VERSION=v3.9.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=93910b1094bc81fcc2ce9544fa0e9063f7d52f84
+ARG NUCLEI_TEMPLATES_REF=4fc7c260a90e4fd63d9fb6a5bcd19b99796cde09
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.8.0
+ARG NUCLEI_VERSION=v3.9.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=93910b1094bc81fcc2ce9544fa0e9063f7d52f84
+ARG NUCLEI_TEMPLATES_REF=4fc7c260a90e4fd63d9fb6a5bcd19b99796cde09
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -7,7 +7,7 @@
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",
-    "version": "v3.8.0"
+    "version": "v3.9.0"
   },
   "subfinder": {
     "module": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder",
@@ -17,6 +17,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "93910b1094bc81fcc2ce9544fa0e9063f7d52f84"
+    "ref": "4fc7c260a90e4fd63d9fb6a5bcd19b99796cde09"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Bump Stackray patch version so deployments can detect the new tested scanner bundle.

`httpx: 89a1173 -> 89a1173; nuclei: v3.8.0 -> v3.9.0; subfinder: v2.14.0 -> v2.14.0; nuclei-templates: 93910b1 -> 4fc7c26`

Release version: `v0.1.16`