### PR TITLE
chore: update scanner pins

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,2 +1,2 @@
 // Single source of truth - keep this in sync with package.json.
-export const APP_VERSION = "0.1.18"
+export const APP_VERSION = "0.1.19"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackray",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "engines": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=479612726bfd53aabf852f74d13349e8fb6dfdc4
+ARG HTTPX_REF=393874cda777c21b1ca7d14b5f7c359c6986597e
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.9.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=a0c27816ac1151b450b78767020e7097bf489ca6
+ARG NUCLEI_TEMPLATES_REF=ffa35164980a981fb28374c317caff2b94e4a607
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=479612726bfd53aabf852f74d13349e8fb6dfdc4
+ARG HTTPX_REF=393874cda777c21b1ca7d14b5f7c359c6986597e
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.9.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=a0c27816ac1151b450b78767020e7097bf489ca6
+ARG NUCLEI_TEMPLATES_REF=ffa35164980a981fb28374c317caff2b94e4a607
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -3,7 +3,7 @@
     "repo": "CarlosCommits/httpx",
     "gitUrl": "https://github.com/CarlosCommits/httpx.git",
     "sourceRef": "dev",
-    "ref": "479612726bfd53aabf852f74d13349e8fb6dfdc4"
+    "ref": "393874cda777c21b1ca7d14b5f7c359c6986597e"
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",
@@ -17,6 +17,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "a0c27816ac1151b450b78767020e7097bf489ca6"
+    "ref": "ffa35164980a981fb28374c317caff2b94e4a607"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Bump Stackray patch version so deployments can detect the new tested scanner bundle.

`httpx: 4796127 -> 393874c; nuclei: v3.9.0 -> v3.9.0; subfinder: v2.14.0 -> v2.14.0; nuclei-templates: a0c2781 -> ffa3516`

Release version: `v0.1.19`