### PR TITLE
fix(scanner): update scanner pins

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=6ef9ab3f30b63c698f21192093a1a7573623007c
+ARG HTTPX_REF=6cea984c142179d6de909e81198386d7022eb262
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.9.0
+ARG NUCLEI_VERSION=v3.10.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=cde321f004e903eb9de7b5e584bbd3f7ec597147
+ARG NUCLEI_TEMPLATES_REF=dee7c015cf20e347097af5e139acf0d5d18af77b
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=6ef9ab3f30b63c698f21192093a1a7573623007c
+ARG HTTPX_REF=6cea984c142179d6de909e81198386d7022eb262
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.9.0
+ARG NUCLEI_VERSION=v3.10.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=cde321f004e903eb9de7b5e584bbd3f7ec597147
+ARG NUCLEI_TEMPLATES_REF=dee7c015cf20e347097af5e139acf0d5d18af77b
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -3,11 +3,11 @@
     "repo": "CarlosCommits/httpx",
     "gitUrl": "https://github.com/CarlosCommits/httpx.git",
     "sourceRef": "dev",
-    "ref": "6ef9ab3f30b63c698f21192093a1a7573623007c"
+    "ref": "6cea984c142179d6de909e81198386d7022eb262"
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",
-    "version": "v3.9.0"
+    "version": "v3.10.0"
   },
   "subfinder": {
     "module": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder",
@@ -17,6 +17,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "cde321f004e903eb9de7b5e584bbd3f7ec597147"
+    "ref": "dee7c015cf20e347097af5e139acf0d5d18af77b"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Leave Stackray's public app version unchanged until a structured release is cut.

`httpx: 6ef9ab3 -> 6cea984; nuclei: v3.9.0 -> v3.10.0; subfinder: v2.14.0 -> v2.14.0; nuclei-templates: cde321f -> dee7c01`