### PR TITLE
fix(scanner): update scanner pins

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=d53c572adcb279b9c8fa74289e5cbbe568228d5f
+ARG HTTPX_REF=35ab81a1c158648245ac8dce10a0aec233b8c79f
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.11.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=a6e28fb218f83d35e774c99066b93d96b68a5ffa
+ARG NUCLEI_TEMPLATES_REF=6994a9cdb63cfdff8b80a5c6359cb71b063f972e
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=d53c572adcb279b9c8fa74289e5cbbe568228d5f
+ARG HTTPX_REF=35ab81a1c158648245ac8dce10a0aec233b8c79f
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \
@@ -15,7 +15,7 @@ FROM golang:1.25-bookworm AS nuclei-builder
 ARG NUCLEI_VERSION=v3.11.0
 ARG SUBFINDER_VERSION=v2.14.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=a6e28fb218f83d35e774c99066b93d96b68a5ffa
+ARG NUCLEI_TEMPLATES_REF=6994a9cdb63cfdff8b80a5c6359cb71b063f972e
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -3,7 +3,7 @@
     "repo": "CarlosCommits/httpx",
     "gitUrl": "https://github.com/CarlosCommits/httpx.git",
     "sourceRef": "dev",
-    "ref": "d53c572adcb279b9c8fa74289e5cbbe568228d5f"
+    "ref": "35ab81a1c158648245ac8dce10a0aec233b8c79f"
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",
@@ -17,6 +17,6 @@
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "a6e28fb218f83d35e774c99066b93d96b68a5ffa"
+    "ref": "6994a9cdb63cfdff8b80a5c6359cb71b063f972e"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Leave Stackray's public app version unchanged until a structured release is cut.

`httpx: d53c572 -> 35ab81a; nuclei: v3.11.0 -> v3.11.0; subfinder: v2.14.0 -> v2.14.0; nuclei-templates: a6e28fb -> 6994a9c`