### PR TITLE
fix(scanner): update scanner pins

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx/cmd/httpx \
   && go install .
 
-FROM golang:1.25-bookworm AS nuclei-builder
+FROM golang:1.26-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.11.1
 ARG SUBFINDER_VERSION=v2.15.0

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.11.0
-ARG SUBFINDER_VERSION=v2.14.0
+ARG NUCLEI_VERSION=v3.11.1
+ARG SUBFINDER_VERSION=v2.15.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=e9f0fe7fa4f5c548bbd1a4d3b65d0f181021e664
+ARG NUCLEI_TEMPLATES_REF=f6797b29233e696fdc28050f6f14fb0ce1f0606d
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -10,7 +10,7 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx/cmd/httpx \
   && go install .
 
-FROM golang:1.25-bookworm AS nuclei-builder
+FROM golang:1.26-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.11.1
 ARG SUBFINDER_VERSION=v2.15.0

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -12,10 +12,10 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 
 FROM golang:1.25-bookworm AS nuclei-builder
 
-ARG NUCLEI_VERSION=v3.11.0
-ARG SUBFINDER_VERSION=v2.14.0
+ARG NUCLEI_VERSION=v3.11.1
+ARG SUBFINDER_VERSION=v2.15.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=e9f0fe7fa4f5c548bbd1a4d3b65d0f181021e664
+ARG NUCLEI_TEMPLATES_REF=f6797b29233e696fdc28050f6f14fb0ce1f0606d
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -7,16 +7,16 @@
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",
-    "version": "v3.11.0"
+    "version": "v3.11.1"
   },
   "subfinder": {
     "module": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder",
-    "version": "v2.14.0"
+    "version": "v2.15.0"
   },
   "nucleiTemplates": {
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "e9f0fe7fa4f5c548bbd1a4d3b65d0f181021e664"
+    "ref": "f6797b29233e696fdc28050f6f14fb0ce1f0606d"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Leave Stackray's public app version unchanged until a structured release is cut.

`httpx: 1410e36 -> 1410e36; nuclei: v3.11.0 -> v3.11.1; subfinder: v2.14.0 -> v2.15.0; nuclei-templates: e9f0fe7 -> f6797b2`