### PR TITLE
fix(scanner): update scanner pins

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -13,9 +13,9 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 FROM golang:1.26-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.11.1
-ARG SUBFINDER_VERSION=v2.15.0
+ARG SUBFINDER_VERSION=v2.16.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=f6797b29233e696fdc28050f6f14fb0ce1f0606d
+ARG NUCLEI_TEMPLATES_REF=24858b4bfabfa86f0bcfd36aea24fb535152b012
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -13,9 +13,9 @@ RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
 FROM golang:1.26-bookworm AS nuclei-builder
 
 ARG NUCLEI_VERSION=v3.11.1
-ARG SUBFINDER_VERSION=v2.15.0
+ARG SUBFINDER_VERSION=v2.16.0
 ARG NUCLEI_TEMPLATES_REPO=https://github.com/projectdiscovery/nuclei-templates.git
-ARG NUCLEI_TEMPLATES_REF=f6797b29233e696fdc28050f6f14fb0ce1f0606d
+ARG NUCLEI_TEMPLATES_REF=24858b4bfabfa86f0bcfd36aea24fb535152b012
 
 RUN go install "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}"
 RUN go install "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFINDER_VERSION}"

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -11,12 +11,12 @@
   },
   "subfinder": {
     "module": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder",
-    "version": "v2.15.0"
+    "version": "v2.16.0"
   },
   "nucleiTemplates": {
     "repo": "projectdiscovery/nuclei-templates",
     "gitUrl": "https://github.com/projectdiscovery/nuclei-templates.git",
     "sourceRef": "main",
-    "ref": "f6797b29233e696fdc28050f6f14fb0ce1f0606d"
+    "ref": "24858b4bfabfa86f0bcfd36aea24fb535152b012"
   }
 }


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Leave Stackray's public app version unchanged until a structured release is cut.

`httpx: 1410e36 -> 1410e36; nuclei: v3.11.1 -> v3.11.1; subfinder: v2.15.0 -> v2.16.0; nuclei-templates: f6797b2 -> 24858b4`