### PR TITLE
fix(scanner): update scanner pins

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=0baa533d865d3f1e6f27c66f2fc9eb5514e8fb07
+ARG HTTPX_REF=7f8237ebf5fc9b953c18d5d6db261637c46abeda
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \

--- a/worker/Dockerfile.dev
+++ b/worker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM golang:1.26-bookworm AS httpx-builder
 
 ARG HTTPX_REPO=https://github.com/CarlosCommits/httpx.git
-ARG HTTPX_REF=0baa533d865d3f1e6f27c66f2fc9eb5514e8fb07
+ARG HTTPX_REF=7f8237ebf5fc9b953c18d5d6db261637c46abeda
 
 RUN git clone --filter=blob:none "${HTTPX_REPO}" /tmp/httpx \
   && cd /tmp/httpx \

--- a/worker/scanner-pins.json
+++ b/worker/scanner-pins.json
@@ -3,7 +3,7 @@
     "repo": "CarlosCommits/httpx",
     "gitUrl": "https://github.com/CarlosCommits/httpx.git",
     "sourceRef": "dev",
-    "ref": "0baa533d865d3f1e6f27c66f2fc9eb5514e8fb07"
+    "ref": "7f8237ebf5fc9b953c18d5d6db261637c46abeda"
   },
   "nuclei": {
     "module": "github.com/projectdiscovery/nuclei/v3/cmd/nuclei",


### PR DESCRIPTION
## Summary
- Update pinned `httpx`, `nuclei`, `subfinder`, and nuclei-template inputs used by the worker image.
- Leave Stackray's public app version unchanged until a structured release is cut.

`httpx: 0baa533 -> 7f8237e; nuclei: v3.11.1 -> v3.11.1; subfinder: v2.16.0 -> v2.16.0; nuclei-templates: 4f708d5 -> 4f708d5`